### PR TITLE
fix: shift + 8 incorrectly mapped to backspace key

### DIFF
--- a/target/Keymapping.h
+++ b/target/Keymapping.h
@@ -118,7 +118,7 @@ const QMap<int, uint8_t> KeyboardManager::keyMap = {
     {Qt::Key_Percent, 0x22}, // key 5
     {Qt::Key_AsciiCircum, 0x23}, // key 6
     {Qt::Key_Ampersand, 0x24}, // key 7
-    {Qt::Key_Asterisk, 0x2A}, // key *
+    {Qt::Key_Asterisk, 0x25}, // key *
     {Qt::Key_ParenLeft, 0x26}, // key 9
     {Qt::Key_ParenRight, 0x27}, // key 0
     {Qt::Key_Underscore, 0x2D}, // key -


### PR DESCRIPTION
This fixes the issue where typing `Shift` + `8` would produce a `Backspace` instead of a asterisk `*`. 

There lies another issue where the keymapping contains duplicate `Key_Asterisk`, however one is for the Numpad and the other is a Shift modifier. It looks like that Qt handles both keys as the same, so we might want to remove the one for 0x55. Otherwise, this should fix that issue.