### PR TITLE
Treat MouseButtonDblClick as MouseButtonPress

### DIFF
--- a/ui/inputhandler.cpp
+++ b/ui/inputhandler.cpp
@@ -74,7 +74,7 @@ bool InputHandler::eventFilter(QObject *watched, QEvent *event)
         handleMouseMoveEvent(mouseEvent);
         return true;
     }
-    if (event->type() == QEvent::MouseButtonPress) {
+    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonDblClick) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent*>(event);
         handleMousePressEvent(mouseEvent);
         return true;


### PR DESCRIPTION
QT apparently has a separate event type for double clicks: if you click the same button quickly a second time, that's not a "mousepressed," that's a "mousedblclick." For us the result is the same, we still just want to send a press event through serial, though.