### PR TITLE
Migrate the Windows compiler from MSVC to MinGW

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -112,6 +112,7 @@ jobs:
         working-directory: ${{ runner.temp }}\build
         run: |
           echo "Building with qmake..."
+          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw81_64\\bin;%PATH%
           qmake -v
           qmake -r ${{ env.SOURCE_DIR }}\openterfaceQT.pro
           if errorlevel 1 exit /b 1

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -103,39 +103,25 @@ jobs:
           version: ${{ env.QT_VERSION }}
           host: windows
           target: desktop
-          arch: win64_msvc2019_64
+          arch: win64_mingw
           dir: ${{ runner.temp }}
           modules: qtmultimedia qtserialport
           setup-python: false
 
-      - name: Download and Unzip Jom
-        if: steps.cache-jom.outputs.cache-hit != 'true'
-        working-directory: ${{ runner.temp }}
+      - name: Set up MinGW shell
         run: |
-          curl -L -o jom.zip "http://download.qt.io/official_releases/jom/jom.zip"
-          7z x jom.zip -ojom
-
-      - name: Create build directory
-        run: mkdir ${{ runner.temp }}\build
-
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
-        with:
-          arch: x64
-
+          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw81_64\\bin;%PATH%
+          
       - name: Build
         working-directory: ${{ runner.temp }}\build
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          
           echo "Building with qmake..."
-          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\msvc2019_64\\bin;%PATH%
           qmake -v
           qmake -r ${{ env.SOURCE_DIR }}\openterfaceQT.pro
           if errorlevel 1 exit /b 1
           
-          echo "Building with jom..."
-          ${{ runner.temp }}\jom\jom -j2
+          echo "Building with mingw32-make..."
+          mingw32-make -j2
           if errorlevel 1 exit /b 1
           
           if not exist release\openterfaceQT.exe (

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -98,21 +98,14 @@ jobs:
           modules: qtmultimedia qtserialport
           setup-python: false
 
-      - name: Set up MinGW shell
-        run: |
-          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw81_64\\bin;%PATH%
-          
       - name: Create build directory
         run: mkdir ${{ runner.temp }}\build
-
-      - name: List Directory Contents
-        run: dir ${{ runner.temp }}\build
 
       - name: Build
         working-directory: ${{ runner.temp }}\build
         run: |
           echo "Building with qmake..."
-          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw81_64\\bin;%PATH%
+          set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw_64\\bin;%PATH%
           qmake -v
           qmake -r ${{ env.SOURCE_DIR }}\openterfaceQT.pro
           if errorlevel 1 exit /b 1

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -68,16 +68,6 @@ jobs:
             qt-6.5.3-windows
             qt-6.5-windows
 
-      - name: Cache Jom
-        id: cache-jom
-        uses: actions/cache@v3
-        with:
-          path: ${{ runner.temp }}/jom
-          key: jom-1.1.3-windows
-          restore-keys: |
-            jom-1.1.3-windows
-            jom-1.1-windows
-
       - name: Update version
         run: |
           if [ "${{ github.event.inputs.increase_version }}" = "true" ]; then
@@ -112,6 +102,12 @@ jobs:
         run: |
           set PATH=${{ runner.temp }}\\Qt\\${{ env.QT_VERSION }}\\mingw81_64\\bin;%PATH%
           
+      - name: Create build directory
+        run: mkdir ${{ runner.temp }}\build
+
+      - name: List Directory Contents
+        run: dir ${{ runner.temp }}\build
+
       - name: Build
         working-directory: ${{ runner.temp }}\build
         run: |

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -135,9 +135,6 @@ jobs:
           echo "Running windeployqt..."
           cd package
           windeployqt --qmldir ${{ env.SOURCE_DIR }} openterfaceQT.exe --compiler-runtime --multimedia
-          copy C:\Windows\System32\concrt140.dll . 
-          copy C:\Windows\System32\vccorlib140.dll .
-          copy C:\Windows\System32\msvcp140.dll .
 
       - name: Move directory
         working-directory: ${{ runner.temp }}\build

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@
 ### For Windows users
 1. Download the package from Github release page, and find the latest version to download according to your os and cpu architecture.
 2. Run the installer and it will install all required drivers and application to your windows. You can run the application from start menu.
-    - Note: If you are running under ARM architecture, an extra step is required to install "Microsoft Visual C++ Redistributable for Visual Studio" which can be downloaded here: [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) 
 
 > Note: Users have reported that the Windows installer is unable to automate driver installation correctly on Windows 11 Version 22H2. You may need to manually download and install the driver from the WCH website. For more details, please refer to this [issue](https://github.com/TechxArtisanStudio/Openterface_QT/issues/138). We are also actively working on a solution to improve driver installation for this version.
 
@@ -179,11 +178,6 @@ sudo reboot
       4. **Reconnect the device**: Unplug and reconnect the OpenTouch interface to see if the mouse and keyboard inputs are now being sent to the target.
 
       If the issue persists, it could also be related to permissions or udev rules. Ensure that your user has the necessary permissions to access the device. Please refer to [For Linux users](#for-linux-users)
-
-
- - "This app can't run on your PC" error during installation
-   - This error occurs when the required Microsoft Visual C++ Redistributable package is not installed on your Windows system
-   - Visit the [Microsoft website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version), download and install the version matching your CPU architecture (x86 or x64), then try installing the application again
   
 
 ## Asking questions and reporting issues


### PR DESCRIPTION
In order to get the smaller package size and remove the dependency of msvc redistributable, changed the complier to MinGW.