### PR TITLE
Add modifier support to virtual keyboard

### DIFF
--- a/host/HostManager.cpp
+++ b/host/HostManager.cpp
@@ -139,11 +139,11 @@ void HostManager::sendCtrlAltDel()
     keyboardManager.sendCtrlAltDel();
 }
 
-void HostManager::handleFunctionKey(int qtKeyCode)
+void HostManager::handleFunctionKey(int keyCode, int modifiers)
 {
-    handleKeyboardAction(qtKeyCode, Qt::NoModifier, true);
-    QTimer::singleShot(50, this, [this, qtKeyCode]() {
-        handleKeyboardAction(qtKeyCode, Qt::NoModifier, false);
+    handleKeyboardAction(keyCode, modifiers, true);
+    QTimer::singleShot(50, this, [this, keyCode, modifiers]() {
+        handleKeyboardAction(keyCode, modifiers, false);
     });
 }
 

--- a/host/HostManager.h
+++ b/host/HostManager.h
@@ -70,7 +70,7 @@ public:
 
     void sendCtrlAltDel();
 
-    void handleFunctionKey(int qtKeyCode);
+    void handleFunctionKey(int keyCode, int modifiers);
 
     void setRepeatingKeystroke(int interval);
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -896,11 +896,6 @@ void MainWindow::versionInfo()
     m_versionInfoManager->showVersionInfo();
 }
 
-void MainWindow::onFunctionKeyPressed(int key)
-{
-    HostManager::getInstance().handleFunctionKey(key);
-}
-
 void MainWindow::onCtrlAltDelPressed()
 {
     HostManager::getInstance().sendCtrlAltDel();

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -197,7 +197,6 @@ protected:
 private slots:
     void onRepeatingKeystrokeChanged(int index);
 
-    void onFunctionKeyPressed(int key);
     void onCtrlAltDelPressed();
     
     void onBaudrateMenuTriggered(QAction* action);

--- a/ui/toolbarmanager.h
+++ b/ui/toolbarmanager.h
@@ -18,36 +18,6 @@ public:
     explicit ToolbarManager(QWidget *parent = nullptr);
     QToolBar* getToolbar() { return toolbar; }
 
-
-    // Define constants for all special keys
-    static const QString KEY_WIN;
-    static const QString KEY_WIN_TOOLTIP;
-    static const QString KEY_PRTSC;
-    static const QString KEY_PRTSC_TOOLTIP;
-    static const QString KEY_SCRLK;
-    static const QString KEY_SCRLK_TOOLTIP;
-    static const QString KEY_PAUSE;
-    static const QString KEY_PAUSE_TOOLTIP;
-    static const QString KEY_INS;
-    static const QString KEY_INS_TOOLTIP;
-    static const QString KEY_HOME;
-    static const QString KEY_HOME_TOOLTIP;
-    static const QString KEY_END;
-    static const QString KEY_END_TOOLTIP;
-    static const QString KEY_PGUP;
-    static const QString KEY_PGUP_TOOLTIP;
-    static const QString KEY_PGDN;
-    static const QString KEY_PGDN_TOOLTIP;
-    static const QString KEY_NUMLK;
-    static const QString KEY_NUMLK_TOOLTIP;
-    static const QString KEY_CAPSLK;
-    static const QString KEY_CAPSLK_TOOLTIP;
-    static const QString KEY_ESC;
-    static const QString KEY_ESC_TOOLTIP;
-    static const QString KEY_DEL;
-    static const QString KEY_DEL_TOOLTIP;
-    static const QList<QPair<QString, QString>> specialKeys;
-
     // Add this line to declare the toggleToolbar function
     void toggleToolbar();
     void updateStyles();
@@ -56,17 +26,30 @@ signals:
     void toolbarVisibilityChanged(bool visible);
 
 private:
+    struct KeyInfo {
+        QString text;
+        QString toolTip;
+        int keyCode;
+    };
+
     static const QString commonButtonStyle;
+
+    // Define constants for all special keys
+    static const QList<KeyInfo> modifierKeys;
+    static const QList<KeyInfo> specialKeys;
+
+    // Dynamic Qt property name for key codes
+    static const char *KEYCODE_PROPERTY;
+    static const char *MODIFIER_PROPERTY;
 
     QToolBar *toolbar;
     void setupToolbar();
-    QPushButton* createFunctionButton(const QString &text);
+    QPushButton *addKeyButton(const QString& text, const QString& toolTip);
 
 private slots:
-    void onFunctionButtonClicked();
+    void onKeyButtonClicked();
     void onCtrlAltDelClicked();
     void onRepeatingKeystrokeChanged(int index);
-    void onSpecialKeyClicked();
 
 };
 


### PR DESCRIPTION
I found some things hard to do because key combinations such as Alt-F4 or Ctrl-Alt-F1 (Linux virtual console key combinations) kept doing stuff on the host computer instead, so I added modifier support to the virtual keyboard.

* Added toggleable virtual Ctrl/Shift/Alt/Win keys
* Physical modifier keys also work with virtual keyboard
* Rearranged keys to bring most useful keys to the front (the ones that will likely affect the host computer)
* Made virtual keyboard buttons unfocusable by mouse (makes it easier to use physical and virtual keyboard at the same time)

One thing I didn't do but thought about doing is removing the Ctrl+Alt+Del button. It can now be done by using the toggleable virtual Ctrl and Alt and the Del button. Having a single button for a key combo that can instantly reboot your Linux computer (depending on your configuration) seems a bit dangerous. I think it would be nice to at least add an "Are you sure?" if it's left in.