### PR TITLE
Fix two segfaults when audio thread exists

### DIFF
--- a/host/audiomanager.cpp
+++ b/host/audiomanager.cpp
@@ -83,6 +83,8 @@ void AudioManager::fadeInVolume(int timeout, int durationInSeconds) {
     // Create a QTimer to handle the volume fade-in
     QTimer *volumeTimer = new QTimer(this);
     connect(volumeTimer, &QTimer::timeout, [this, volumeTimer, increment]() {
+        if (!m_audioThread) return;
+
         qreal currentVolume = m_audioThread->volume();
 
         if (currentVolume < 1.0) {

--- a/host/audiothread.cpp
+++ b/host/audiothread.cpp
@@ -94,17 +94,18 @@ void AudioThread::run()
         }
 
         // Cleanup
-        if (m_audioSource) {
-            qDebug() << "Stopping audio source.";
-            m_audioSource->stop();
-            delete m_audioSource;
-            m_audioSource = nullptr;
-        }
 
         if (m_audioIODevice) {
             qDebug() << "Closing audio IO device.";
             m_audioIODevice->close();
             m_audioIODevice = nullptr;
+        }
+
+        if (m_audioSource) {
+            qDebug() << "Stopping audio source.";
+            m_audioSource->stop();
+            delete m_audioSource;
+            m_audioSource = nullptr;
         }
 
         if (m_sinkIODevice) {


### PR DESCRIPTION
* The audio source and its IO device were being destroyed in the wrong order (destroying the source invalidates the IO device)
* The timer in AudioManager::fadeInVolume would cause a segfault if the audio thread was destroyed while the timer was running