### PR TITLE
Check for serial ports more often

### DIFF
--- a/serial/SerialPortManager.cpp
+++ b/serial/SerialPortManager.cpp
@@ -52,7 +52,8 @@ void SerialPortManager::observeSerialPortNotification(){
 
     connect(serialThread, &QThread::started, serialTimer, [this]() {
         connect(serialTimer, &QTimer::timeout, this, &SerialPortManager::checkSerialPort);
-        serialTimer->start(5000);
+        checkSerialPort();
+        serialTimer->start(500);
     });
 
     connect(serialThread, &QThread::finished, serialTimer, &QObject::deleteLater);
@@ -128,8 +129,6 @@ void SerialPortManager::checkSerialPorts() {
  * Check the serial port connection status
  */
 void SerialPortManager::checkSerialPort() {
-    qCDebug(log_core_serial) << "Check serial port.";
-
     // Check if any new ports is connected, compare to the last port list
     checkSerialPorts();
 


### PR DESCRIPTION
Reduced the poll interval from 5s to 0.5s and added an extra check at the start. This reduces the up to 5 second delay before input works.

I'm assuming the long delay was a mistake and not a mitigation to some hardware problem that was found while testing. I didn't notice any problems with the more frequent polling.