### PR TITLE
Fix memory allocation problems

### DIFF
--- a/serial/SerialPortManager.cpp
+++ b/serial/SerialPortManager.cpp
@@ -33,7 +33,7 @@
 
 Q_LOGGING_CATEGORY(log_core_serial, "opf.core.serial")
 
-SerialPortManager::SerialPortManager(QObject *parent) : QObject(parent), serialThread(new QThread(nullptr)), serialTimer(new QTimer(nullptr)){
+SerialPortManager::SerialPortManager(QObject *parent) : QObject(parent), serialPort(nullptr), serialThread(new QThread(nullptr)), serialTimer(new QTimer(nullptr)){
     qCDebug(log_core_serial) << "Initialize serial port.";
 
     connect(this, &SerialPortManager::serialPortConnected, this, &SerialPortManager::onSerialPortConnected);
@@ -334,8 +334,6 @@ SerialPortManager::~SerialPortManager() {
         serialThread->quit();
         serialThread->wait();
     }
-    delete serialTimer;
-    delete serialThread;
     delete serialPort;
 }
 

--- a/target/MouseManager.h
+++ b/target/MouseManager.h
@@ -124,6 +124,7 @@ class MouseManager : public QObject
 
 public:
     explicit MouseManager(QObject *parent = nullptr);
+    ~MouseManager();
 
     void handleAbsoluteMouseAction(int x, int y, int mouse_event, int wheelMovement);
     void handleRelativeMouseAction(int dx, int dy, int mouse_event, int wheelMovement);

--- a/ui/audiopage.cpp
+++ b/ui/audiopage.cpp
@@ -33,11 +33,6 @@ AudioPage::AudioPage(QWidget *parent) : QWidget(parent)
     setupUI();
 }
 
-AudioPage::~AudioPage()
-{
-    delete this;
-}
-
 void AudioPage::setupUI()
 {
     QLabel *audioLabel = new QLabel(

--- a/ui/audiopage.h
+++ b/ui/audiopage.h
@@ -37,7 +37,6 @@ class AudioPage : public QWidget
     Q_OBJECT
 public:
     explicit AudioPage(QWidget *parent = nullptr);
-    ~AudioPage();
     void setupUI();
 private:
     QLabel *audioLabel;

--- a/ui/hardwarepage.cpp
+++ b/ui/hardwarepage.cpp
@@ -30,11 +30,6 @@ HardwarePage::HardwarePage(QWidget *parent) : QWidget(parent)
     setupUI();
 }
 
-HardwarePage::~HardwarePage()
-{
-    delete this;
-}
-
 void HardwarePage::setupUI()
 {
     // UI setup implementation

--- a/ui/hardwarepage.h
+++ b/ui/hardwarepage.h
@@ -41,7 +41,6 @@ class HardwarePage : public QWidget
     Q_OBJECT
 public:
     explicit HardwarePage(QWidget *parent = nullptr);
-    ~HardwarePage();
     void setupUI();
     void applyHardwareSetting();
     void initHardwareSetting();

--- a/ui/inputhandler.cpp
+++ b/ui/inputhandler.cpp
@@ -110,24 +110,24 @@ bool InputHandler::eventFilter(QObject *watched, QEvent *event)
 
 void InputHandler::handleMouseMoveEvent(QMouseEvent *event)
 {
-    MouseEventDTO* eventDto = calculateMouseEventDto(event);   
+    QScopedPointer<MouseEventDTO> eventDto(calculateMouseEventDto(event));
     eventDto->setMouseButton(isDragging() ? lastMouseButton : 0);
 
     //Only handle the event if it's under absolute mouse control or relative mode is enabled
     if(!eventDto->isAbsoluteMode() && !m_videoPane->isRelativeModeEnabled()) return;
 
-    HostManager::getInstance().handleMouseMove(eventDto);
+    HostManager::getInstance().handleMouseMove(eventDto.get());
 }
 
 void InputHandler::handleMousePressEvent(QMouseEvent* event)
 {
-    MouseEventDTO* eventDto = calculateMouseEventDto(event);
+    QScopedPointer<MouseEventDTO> eventDto(calculateMouseEventDto(event));
     eventDto->setMouseButton(lastMouseButton = getMouseButton(event));
     setDragging(true);
 
     if(!eventDto->isAbsoluteMode()) m_videoPane->setRelativeModeEnabled(true);
 
-    HostManager::getInstance().handleMousePress(eventDto);
+    HostManager::getInstance().handleMousePress(eventDto.get());
 
     if(eventDto->isAbsoluteMode()){
         m_videoPane->showHostMouse();
@@ -138,18 +138,18 @@ void InputHandler::handleMousePressEvent(QMouseEvent* event)
 
 void InputHandler::handleMouseReleaseEvent(QMouseEvent* event)
 {
-    MouseEventDTO* eventDto = calculateMouseEventDto(event);
+    QScopedPointer<MouseEventDTO> eventDto(calculateMouseEventDto(event));
     setDragging(false);
-    HostManager::getInstance().handleMouseRelease(eventDto);
+    HostManager::getInstance().handleMouseRelease(eventDto.get());
 }
 
 void InputHandler::handleWheelEvent(QWheelEvent *event)
 {
-    MouseEventDTO* eventDto = new MouseEventDTO(lastX, lastY, GlobalVar::instance().isAbsoluteMouseMode());
+    QScopedPointer<MouseEventDTO> eventDto(new MouseEventDTO(lastX, lastY, GlobalVar::instance().isAbsoluteMouseMode()));
 
     eventDto->setWheelDelta(event->angleDelta().y());
 
-    HostManager::getInstance().handleMouseScroll(eventDto);
+    HostManager::getInstance().handleMouseScroll(eventDto.get());
 }
 
 void InputHandler::setDragging(bool dragging)

--- a/ui/logpage.cpp
+++ b/ui/logpage.cpp
@@ -44,13 +44,6 @@ LogPage::LogPage(QWidget *parent) : QWidget(parent)
     // initLogSettings();
 }
 
-LogPage::~LogPage()
-{
-    // Destructor implementation
-    delete this;
-}
-
-
 void LogPage::setupUI()
 {
     // UI setup implementation

--- a/ui/logpage.h
+++ b/ui/logpage.h
@@ -39,7 +39,6 @@ class LogPage : public QWidget
 
 public:
     explicit LogPage(QWidget *parent = nullptr);
-    ~LogPage();
     void setupUI();
     void browseLogPath();
     void initLogSettings();

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -844,6 +844,7 @@ void MainWindow::configureSettings() {
         connect(videoPage, &VideoPage::videoSettingsChanged, this, &MainWindow::onVideoSettingsChanged);
         // connect the finished signal to the set the dialog pointer to nullptr
         connect(settingDialog, &QDialog::finished, this, [this](){
+            settingDialog->deleteLater();
             settingDialog = nullptr;
         });
         settingDialog->show();
@@ -861,6 +862,7 @@ void MainWindow::debugSerialPort() {
         serialPortDebugDialog = new SerialPortDebugDialog();
         // connect the finished signal to the set the dialog pointer to nullptr
         connect(serialPortDebugDialog, &QDialog::finished, this, [this]() {
+            serialPortDebugDialog->deleteLater();
             serialPortDebugDialog = nullptr;
         });
         serialPortDebugDialog->show();

--- a/ui/serialportdebugdialog.cpp
+++ b/ui/serialportdebugdialog.cpp
@@ -69,11 +69,6 @@ SerialPortDebugDialog::SerialPortDebugDialog(QWidget *parent)
     loadSettings();
 }
 
-SerialPortDebugDialog::~SerialPortDebugDialog()
-{
-    // Remove delete this - QObject hierarchy will handle cleanup
-}
-
 void SerialPortDebugDialog::createFilterCheckBox()
 {
     QGridLayout *gridLayout = new QGridLayout(filterCheckboxWidget);

--- a/ui/serialportdebugdialog.h
+++ b/ui/serialportdebugdialog.h
@@ -31,7 +31,6 @@ class SerialPortDebugDialog : public QDialog {
     Q_OBJECT
 public:
     explicit SerialPortDebugDialog(QWidget *parent = nullptr);
-    ~SerialPortDebugDialog();
 
 private slots:
     void handleSerialData(const QByteArray &data, bool isReceived);

--- a/ui/settingdialog.cpp
+++ b/ui/settingdialog.cpp
@@ -85,9 +85,6 @@ SettingDialog::SettingDialog(CameraManager *cameraManager, QWidget *parent)
 SettingDialog::~SettingDialog()
 {
     delete ui;
-    // Ensure all dynamically allocated memory is freed
-    qDeleteAll(settingTree->invisibleRootItem()->takeChildren());
-    delete this;
 }
 
 void SettingDialog::createSettingTree() {

--- a/ui/statuswidget.cpp
+++ b/ui/statuswidget.cpp
@@ -24,7 +24,7 @@
 #include <QSvgRenderer>
 #include <QPainter>
 
-StatusWidget::StatusWidget(QWidget *parent) : QWidget(parent) {
+StatusWidget::StatusWidget(QWidget *parent) : QWidget(parent), m_captureWidth(0), m_captureHeight(0) {
     keyboardIndicatorsLabel = new QLabel("", this);
     statusLabel = new QLabel("", this);
     resolutionLabel = new QLabel("💻:", this);

--- a/ui/videopage.cpp
+++ b/ui/videopage.cpp
@@ -37,11 +37,6 @@ VideoPage::VideoPage(CameraManager *cameraManager, QWidget *parent) : QWidget(pa
     setupUI();
 }
 
-VideoPage::~VideoPage()
-{
-    delete this;
-}
-
 void VideoPage::setupUI()
 {
     // UI setup implementation

--- a/ui/videopage.h
+++ b/ui/videopage.h
@@ -76,7 +76,6 @@ class VideoPage : public QWidget
     Q_OBJECT
 public:
     explicit VideoPage(CameraManager *cameraManager, QWidget *parent = nullptr);
-    ~VideoPage();
     void setupUI();
     void initVideoSettings();
     void applyVideoSettings();

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,0 +1,33 @@
+{
+   TLS related: tls_get_addr_tail
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:tls_get_addr_tail
+}
+
+{
+   TLS related: update_tls_slotinfo
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   ...
+   fun:update_tls_slotinfo
+}
+
+{
+   QApplicationPrivate::init private
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN22QGuiApplicationPrivate4initEv
+}
+
+{
+   QApplicationPrivate::init private
+   Memcheck:Param
+   writev(vector[0])
+   ...
+   fun:_ZN22QGuiApplicationPrivate4initEv
+}


### PR DESCRIPTION
Fixed multiple memory leaks, double frees and accesses to uninitialized memory. Found by gdb and valgrind. Added simple suppression file for valgrind to suppress Qt internals that are detected as leaks and cannot be fixed.