### PR TITLE
Add Windows Media Foundation backend and FFmpeg DirectShow support

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -591,6 +591,7 @@ jobs:
           cp /mingw64/bin/liblzma-5.dll ${{ env.PACKAGE_DIR }} || echo "Warning: liblzma-5.dll not found"
           cp /mingw64/bin/zlib1.dll ${{ env.PACKAGE_DIR }} || echo "Warning: zlib1.dll not found"
           cp /mingw64/bin/libmfx-1.dll ${{ env.PACKAGE_DIR }} || echo "Warning: libmfx-1.dll not found"
+          cp /mingw64/bin/libssp-0.dll ${{ env.PACKAGE_DIR }} || echo "Warning: libssp-0.dll not found"
           # NOTE: Do NOT copy libwinpthread, libgcc, libstdc++ here!
           # Let windeployqt copy them from Qt's MinGW installation for ABI compatibility
           echo "Copying translation & keyboard layouts files..."

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -591,7 +591,15 @@ jobs:
           cp /mingw64/bin/liblzma-5.dll ${{ env.PACKAGE_DIR }} || echo "Warning: liblzma-5.dll not found"
           cp /mingw64/bin/zlib1.dll ${{ env.PACKAGE_DIR }} || echo "Warning: zlib1.dll not found"
           cp /mingw64/bin/libmfx-1.dll ${{ env.PACKAGE_DIR }} || echo "Warning: libmfx-1.dll not found"
-          cp /mingw64/bin/libssp-0.dll ${{ env.PACKAGE_DIR }} || echo "Warning: libssp-0.dll not found"
+          # libssp-0.dll may live outside /mingw64/bin depending on MSYS2 layout — search broadly
+          if [ ! -f "${{ env.PACKAGE_DIR }}/libssp-0.dll" ]; then
+            SSP_DLL=$(find /mingw64 /usr /c -name "libssp-0.dll" 2>/dev/null | head -1)
+            if [ -n "$SSP_DLL" ]; then
+              cp "$SSP_DLL" ${{ env.PACKAGE_DIR }} && echo "✓ Copied libssp-0.dll from $SSP_DLL"
+            else
+              echo "Warning: libssp-0.dll not found anywhere on runner"
+            fi
+          fi
           # NOTE: Do NOT copy libwinpthread, libgcc, libstdc++ here!
           # Let windeployqt copy them from Qt's MinGW installation for ABI compatibility
           echo "Copying translation & keyboard layouts files..."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ endif()
 # Debug output for linking
 message(STATUS "Hardware acceleration libraries to link: ${HWACCEL_LIBRARIES}")
 
+# Add FFmpeg compatibility shim for static libs built with newer MinGW-w64
+if(WIN32)
+    target_sources(${PROJECT_NAME} PRIVATE host/backend/ffmpeg_compat_shim.c)
+    message(STATUS "Adding FFmpeg compatibility shim for 64-bit time functions")
+endif()
+
 # Link Qt6 image format plugins statically for static builds (only if targets exist)
 if(OPENTERFACE_BUILD_STATIC)
     set(_qt_image_plugins Qt6::QJpegPlugin Qt6::QGifPlugin Qt6::QICOPlugin Qt6::QSvgPlugin)
@@ -138,6 +144,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core Qt6::Widgets Qt6::Gui Qt
 # Link Windows HID and SetupAPI libraries
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE hid setupapi cfgmgr32 ole32)
+
+    # Link compatibility libraries for FFmpeg static libs built with newer MinGW-w64
+    # These resolve 64-bit time functions and stack protector symbols
+    target_link_libraries(${PROJECT_NAME} PRIVATE ssp)
+    target_link_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fstack-protector-strong)
 endif()
 
 # Link X11 libraries for Linux builds to resolve X11 symbols used in overlay code
@@ -309,6 +321,18 @@ if(NOT WIN32)
     if(OPENTERFACE_BUILD_STATIC)
         target_link_options(openterfaceQT PRIVATE -Wl,--wrap=dlopen)
     endif()
+endif()
+
+# Link Media Foundation libraries on Windows
+if(WIN32)
+    target_link_libraries(openterfaceQT PRIVATE
+        mf
+        mfplat
+        mfreadwrite
+        mfuuid
+        wmcodecdspuuid
+    )
+    message(STATUS "Linked Media Foundation libraries for Windows video capture")
 endif()
 
 # Add DBus on Unix systems (excluding macOS)

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -61,6 +61,7 @@ set(HOST_SOURCES
     host/backend/ffmpeg/ffmpeg_device_validator.cpp host/backend/ffmpeg/ffmpeg_device_validator.h
     host/backend/ffmpeg/ffmpeg_hotplug_handler.cpp host/backend/ffmpeg/ffmpeg_hotplug_handler.h
     host/backend/ffmpeg/ffmpeg_capture_manager.cpp host/backend/ffmpeg/ffmpeg_capture_manager.h
+    host/backend/ffmpeg/ffmpeg_amd_detector.cpp host/backend/ffmpeg/ffmpeg_amd_detector.h
     host/backend/ffmpeg/icapture_frame_reader.h
     host/backend/ffmpeg/ffmpegutils.h
 )
@@ -88,6 +89,16 @@ if(NOT WIN32)
         host/backend/gstreamer/pipelinebuilder.h
         host/backend/gstreamer/pipelinefactory.h
         host/backend/gstreamer/gstreamerhelpers.h
+    )
+endif()
+
+# Add Media Foundation backend on Windows
+if(WIN32)
+    list(APPEND HOST_SOURCES
+        host/backend/mf/mfbackendhandler.cpp host/backend/mf/mfbackendhandler.h
+        host/backend/mf/mf_capture_manager.cpp host/backend/mf/mf_capture_manager.h
+        host/backend/mf/mf_device_enumerator.cpp host/backend/mf/mf_device_enumerator.h
+        host/backend/mf/mf_frame_processor.cpp host/backend/mf/mf_frame_processor.h
     )
 endif()
 

--- a/host/backend/ffmpeg/ffmpeg_amd_detector.cpp
+++ b/host/backend/ffmpeg/ffmpeg_amd_detector.cpp
@@ -1,0 +1,142 @@
+#include "ffmpeg_amd_detector.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <cfgmgr32.h>
+#include <setupapi.h>
+#include <devguid.h>
+
+// MinGW may not define SPDRP_DEVICE_DESCRIPTION in all SDK versions
+#ifndef SPDRP_DEVICE_DESCRIPTION
+#define SPDRP_DEVICE_DESCRIPTION 0x0000000CUL
+#endif
+
+#pragma comment(lib, "setupapi.lib")
+#endif
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(log_ffmpeg_backend)
+
+bool FFmpegAmdDetector::isAmdIntegratedGpuDetected()
+{
+#ifndef Q_OS_WIN
+    return false;
+#else
+    HDEVINFO deviceInfo = SetupDiGetClassDevs(&GUID_DEVCLASS_DISPLAY, nullptr, nullptr, DIGCF_PRESENT);
+    if (deviceInfo == INVALID_HANDLE_VALUE) {
+        qCWarning(log_ffmpeg_backend) << "Failed to enumerate display adapters";
+        return false;
+    }
+
+    bool foundAmdIgpu = false;
+    SP_DEVINFO_DATA deviceInfoData;
+    deviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+
+    for (DWORD i = 0; SetupDiEnumDeviceInfo(deviceInfo, i, &deviceInfoData); i++) {
+        wchar_t descriptionBuffer[256] = {0};
+        DWORD requiredSize = 0;
+
+        BOOL result = SetupDiGetDeviceRegistryPropertyW(
+            deviceInfo, &deviceInfoData,
+            SPDRP_DEVICE_DESCRIPTION, nullptr,
+            reinterpret_cast<PBYTE>(descriptionBuffer),
+            sizeof(descriptionBuffer), &requiredSize
+        );
+
+        if (!result) {
+            continue;
+        }
+
+        QString description = QString::fromWCharArray(descriptionBuffer);
+        QString lowerDesc = description.toLower();
+
+        bool isAmd = lowerDesc.contains("amd") || lowerDesc.contains("radeon");
+        bool isNvidia = lowerDesc.contains("nvidia") || lowerDesc.contains("geforce");
+        bool isIntel = lowerDesc.contains("intel") || lowerDesc.contains("uhd") || lowerDesc.contains("iris");
+
+        if (isAmd) {
+            // Check if it's an integrated GPU by looking for iGPU keywords
+            bool isIntegrated = lowerDesc.contains("integrated") ||
+                               lowerDesc.contains("apu") ||
+                               lowerDesc.contains("vega") ||
+                               lowerDesc.contains("gfx") ||
+                               lowerDesc.contains("renoir") ||
+                               lowerDesc.contains("cezanne") ||
+                               lowerDesc.contains("rembrandt") ||
+                               lowerDesc.contains("mendocino") ||
+                               lowerDesc.contains("phoenix") ||
+                               lowerDesc.contains("strix");
+
+            // Also check adapter RAM — iGPUs typically have < 1GB dedicated VRAM
+            bool isLikelyIgpu = false;
+            wchar_t ramBuffer[256] = {0};
+            if (SetupDiGetDeviceRegistryPropertyW(
+                    deviceInfo, &deviceInfoData,
+                    SPDRP_HARDWAREID, nullptr,
+                    reinterpret_cast<PBYTE>(ramBuffer),
+                    sizeof(ramBuffer), &requiredSize
+                )) {
+                // Hardware ID check: PCI\VEN_1002 = AMD
+                QString hwId = QString::fromWCharArray(ramBuffer);
+                if (hwId.contains("VEN_1002", Qt::CaseInsensitive) && isIntegrated) {
+                    isLikelyIgpu = true;
+                }
+            }
+
+            if (isIntegrated || isLikelyIgpu) {
+                qCInfo(log_ffmpeg_backend) << "AMD iGPU detected:" << description;
+                foundAmdIgpu = true;
+                break;
+            }
+        }
+
+        Q_UNUSED(isNvidia);
+        Q_UNUSED(isIntel);
+    }
+
+    SetupDiDestroyDeviceInfoList(deviceInfo);
+
+    if (!foundAmdIgpu) {
+        qCDebug(log_ffmpeg_backend) << "No AMD integrated GPU detected";
+    }
+
+    return foundAmdIgpu;
+#endif
+}
+
+QString FFmpegAmdDetector::getAmdGpuInfo()
+{
+#ifndef Q_OS_WIN
+    return QString();
+#else
+    HDEVINFO deviceInfo = SetupDiGetClassDevs(&GUID_DEVCLASS_DISPLAY, nullptr, nullptr, DIGCF_PRESENT);
+    if (deviceInfo == INVALID_HANDLE_VALUE) {
+        return QString();
+    }
+
+    QStringList amdGpus;
+    SP_DEVINFO_DATA deviceInfoData;
+    deviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+
+    for (DWORD i = 0; SetupDiEnumDeviceInfo(deviceInfo, i, &deviceInfoData); i++) {
+        wchar_t descriptionBuffer[256] = {0};
+        DWORD requiredSize = 0;
+
+        if (SetupDiGetDeviceRegistryPropertyW(
+                deviceInfo, &deviceInfoData,
+                SPDRP_DEVICE_DESCRIPTION, nullptr,
+                reinterpret_cast<PBYTE>(descriptionBuffer),
+                sizeof(descriptionBuffer), &requiredSize
+            )) {
+            QString description = QString::fromWCharArray(descriptionBuffer);
+            if (description.toLower().contains("amd") || description.toLower().contains("radeon")) {
+                amdGpus.append(description);
+            }
+        }
+    }
+
+    SetupDiDestroyDeviceInfoList(deviceInfo);
+    return amdGpus.join(", ");
+#endif
+}

--- a/host/backend/ffmpeg/ffmpeg_amd_detector.h
+++ b/host/backend/ffmpeg/ffmpeg_amd_detector.h
@@ -1,0 +1,12 @@
+#ifndef FFMPEG_AMD_DETECTOR_H
+#define FFMPEG_AMD_DETECTOR_H
+
+#include <QString>
+
+class FFmpegAmdDetector {
+public:
+    static bool isAmdIntegratedGpuDetected();
+    static QString getAmdGpuInfo();
+};
+
+#endif // FFMPEG_AMD_DETECTOR_H

--- a/host/backend/ffmpeg/ffmpeg_device_manager.cpp
+++ b/host/backend/ffmpeg/ffmpeg_device_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "ffmpeg_device_manager.h"
 #include "ffmpeg_hardware_accelerator.h"
+#include "ffmpeg_amd_detector.h"
 #include "global.h"
 #include "ui/globalsetting.h"
 
@@ -214,6 +215,8 @@ bool FFmpegDeviceManager::InitializeInputStream(const QString& device_path, cons
     AVDictionary* options = nullptr;
     av_dict_set(&options, "video_size", QString("%1x%2").arg(resolution.width()).arg(resolution.height()).toUtf8().constData(), 0);
     av_dict_set(&options, "framerate", QString::number(framerate).toUtf8().constData(), 0);
+    av_dict_set(&options, "input_format", "mjpeg", 0);
+    av_dict_set(&options, "preset", "preview", 0);
     
     // ============ MJPEG QUALITY OPTIMIZATIONS ============
     
@@ -260,11 +263,13 @@ bool FFmpegDeviceManager::InitializeInputStream(const QString& device_path, cons
         format_context_->interrupt_callback.callback = FFmpegDeviceManager::InterruptCallback;
         format_context_->interrupt_callback.opaque = this;
         
-        // Try without codec specification
+        // Try without codec specification (auto-detect)
         AVDictionary* fallbackOptions = nullptr;
         av_dict_set(&fallbackOptions, "video_size", QString("%1x%2").arg(resolution.width()).arg(resolution.height()).toUtf8().constData(), 0);
         av_dict_set(&fallbackOptions, "framerate", QString::number(framerate).toUtf8().constData(), 0);
-        av_dict_set(&fallbackOptions, "rtbufsize", "8M", 0);  // Keep low-latency buffer for KVM
+        av_dict_set(&fallbackOptions, "rtbufsize", "16M", 0);
+        av_dict_set(&fallbackOptions, "flags", "low_delay", 0);
+        av_dict_set(&fallbackOptions, "timeout", "5000000", 0);
         
         ret = avformat_open_input(&format_context_, device_path.toUtf8().constData(), inputFormat, &fallbackOptions);
         av_dict_free(&fallbackOptions);
@@ -540,13 +545,27 @@ bool FFmpegDeviceManager::SetupDecoder(FFmpegHardwareAccelerator* hw_accelerator
     codec_context_->skip_loop_filter = AVDISCARD_NONE;     // Full loop filter
     
     // ============ MJPEG-SPECIFIC QUALITY SETTINGS ============
-    
-    // Use optimal thread count based on CPU cores (max 8 for stability)
-    // Dynamic threading for better CPU utilization
-    int optimal_threads = std::min(8, std::max(2, QThread::idealThreadCount()));
+
+    // AMD iGPU OPTIMIZATION: On AMD integrated GPUs, the CPU and GPU share memory bandwidth.
+    // Frame-level threading (FF_THREAD_FRAME) buffers multiple frames, increasing latency
+    // and competing with the display pipeline for memory bandwidth.
+    // Use slice-only threading on AMD iGPUs for lower latency and better system responsiveness.
+    bool isAmdIgpu = FFmpegAmdDetector::isAmdIntegratedGpuDetected();
+    int optimal_threads;
+    int thread_type_flags;
+
+    if (isAmdIgpu) {
+        optimal_threads = std::min(6, std::max(2, QThread::idealThreadCount()));
+        thread_type_flags = FF_THREAD_SLICE;  // Slice-only for lower latency and less memory pressure
+        qCInfo(log_ffmpeg_backend) << "AMD iGPU detected: using slice-only threading for lower latency";
+    } else {
+        optimal_threads = std::min(8, std::max(2, QThread::idealThreadCount()));
+        thread_type_flags = FF_THREAD_FRAME | FF_THREAD_SLICE;  // Hybrid threading on non-iGPU systems
+    }
+
     codec_context_->thread_count = optimal_threads;
-    codec_context_->thread_type = FF_THREAD_FRAME | FF_THREAD_SLICE;  // Enable both frame and slice threading
-    
+    codec_context_->thread_type = thread_type_flags;
+
     // LATENCY FIX: Hardware decoders (QSV, CUDA) manage their own internal parallelism.
     // Setting FF_THREAD_FRAME at the FFmpeg host level forces it to buffer thread_count frames
     // before yielding the first decoded frame — that is thread_count/fps seconds of added latency.

--- a/host/backend/ffmpeg/ffmpeg_hotplug_handler.cpp
+++ b/host/backend/ffmpeg/ffmpeg_hotplug_handler.cpp
@@ -32,6 +32,13 @@
 #include <QMediaDevices>
 #include <QCameraDevice>
 
+#ifdef HAVE_FFMPEG
+extern "C" {
+#include <libavdevice/avdevice.h>
+#include <libavformat/avformat.h>
+}
+#endif
+
 Q_DECLARE_LOGGING_CATEGORY(log_ffmpeg_backend)
 
 FFmpegHotplugHandler::FFmpegHotplugHandler(FFmpegDeviceValidator* validator, QObject* parent)
@@ -353,4 +360,47 @@ void FFmpegHotplugHandler::OnDeviceCheckTimer()
         device_check_timer_->stop();
         HandleDeviceActivation(expected_device_path_);
     }
+}
+
+QList<FFmpegHotplugHandler::DshowDeviceInfo> FFmpegHotplugHandler::EnumerateDirectShowDevices()
+{
+    QList<DshowDeviceInfo> devices;
+
+#ifdef HAVE_FFMPEG
+    avdevice_register_all();
+
+    const AVInputFormat* inputFormat = av_find_input_format("dshow");
+    if (!inputFormat) {
+        qCWarning(log_ffmpeg_backend) << "DirectShow input format not available for device enumeration";
+        return devices;
+    }
+
+    AVDeviceInfoList* deviceList = nullptr;
+    int ret = avdevice_list_input_sources(inputFormat, nullptr, nullptr, &deviceList);
+
+    if (ret < 0 || !deviceList) {
+        qCDebug(log_ffmpeg_backend) << "avdevice_list_input_sources failed, falling back to Qt device list";
+        return devices;
+    }
+
+    for (int i = 0; i < deviceList->nb_devices; i++) {
+        AVDeviceInfo* dev = deviceList->devices[i];
+        if (!dev) continue;
+
+        DshowDeviceInfo info;
+        info.index = i;
+        info.name = QString("video=%1").arg(QString::fromUtf8(dev->device_description ? dev->device_description : dev->device_name));
+        info.description = QString::fromUtf8(dev->device_description ? dev->device_description : dev->device_name);
+        devices.append(info);
+
+        qCDebug(log_ffmpeg_backend) << "DirectShow device[" << i << "]:" << info.description
+                                    << "(" << dev->device_name << ")";
+    }
+
+    avdevice_free_list_devices(&deviceList);
+#else
+    qCDebug(log_ffmpeg_backend) << "FFmpeg not available, cannot enumerate DirectShow devices";
+#endif
+
+    return devices;
 }

--- a/host/backend/ffmpeg/ffmpeg_hotplug_handler.h
+++ b/host/backend/ffmpeg/ffmpeg_hotplug_handler.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
+#include <QList>
 
 // Forward declarations
 class HotplugMonitor;
@@ -69,6 +70,14 @@ public:
     QString GetCurrentDevicePortChain() const { return current_device_port_chain_; }
     QString GetCurrentDevice() const { return current_device_; }
     bool IsWaitingForDevice() const { return waiting_for_device_; }
+
+    // Device enumeration
+    struct DshowDeviceInfo {
+        QString name;       // DirectShow-friendly name (e.g., "video=Device Name")
+        QString description;
+        int index;
+    };
+    static QList<DshowDeviceInfo> EnumerateDirectShowDevices();
 
 signals:
     // Device state signals - forwarded to FFmpegBackendHandler

--- a/host/backend/ffmpeg_compat_shim.c
+++ b/host/backend/ffmpeg_compat_shim.c
@@ -1,0 +1,31 @@
+/*
+ * Compatibility shim for FFmpeg static libs built with newer MinGW-w64.
+ * Bridges 64-bit time functions and stack protector symbols to older MinGW 11.2.0.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 64-bit time function wrappers - map to 32-bit versions (fine for Windows) */
+#include <time.h>
+
+int clock_gettime64(int clock_id, struct timespec *ts) {
+    return clock_gettime(clock_id, ts);
+}
+
+int nanosleep64(const struct timespec *req, struct timespec *rem) {
+    return nanosleep(req, rem);
+}
+
+/* pthread cond timedwait - delegate to regular version */
+int pthread_cond_timedwait64(void *cond, void *mutex, const struct timespec *abstime) {
+    /* Forward to the regular pthread_cond_timedwait from libwinpthread */
+    typedef int (*pthread_cond_timedwait_fn)(void*, void*, const struct timespec*);
+    /* libwinpthread exports pthread_cond_timedwait - just call it */
+    extern int pthread_cond_timedwait(void *cond, void *mutex, const struct timespec *abstime);
+    return pthread_cond_timedwait(cond, mutex, abstime);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/host/backend/mf/mf_capture_manager.cpp
+++ b/host/backend/mf/mf_capture_manager.cpp
@@ -1,0 +1,405 @@
+#include "mf_capture_manager.h"
+#include "mf_frame_processor.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+#pragma comment(lib, "mf.lib")
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "mfuuid.lib")
+#pragma comment(lib, "mfreadwrite.lib")
+#pragma comment(lib, "ole32.lib")
+#endif
+
+#include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(log_multimedia_backend)
+
+// MfCaptureThread implementation
+
+MfCaptureThread::MfCaptureThread(QObject* parent)
+    : QThread(parent)
+    , sourceReader_(nullptr)
+    , frameProcessor_(nullptr)
+    , running_(false)
+{
+}
+
+void MfCaptureThread::setRunning(bool running)
+{
+    running_ = running;
+}
+
+void MfCaptureThread::setSourceReader(IMFSourceReader* reader)
+{
+    sourceReader_ = reader;
+}
+
+void MfCaptureThread::setFrameProcessor(MfFrameProcessor* processor)
+{
+    frameProcessor_ = processor;
+}
+
+void MfCaptureThread::run()
+{
+#ifndef Q_OS_WIN
+    qCWarning(log_multimedia_backend) << "Media Foundation capture thread not available on non-Windows";
+    return;
+#else
+    qCInfo(log_multimedia_backend) << "Media Foundation capture thread started";
+
+    if (!sourceReader_ || !frameProcessor_) {
+        qCCritical(log_multimedia_backend) << "Source reader or frame processor not set";
+        emit captureError("Source reader or frame processor not set");
+        return;
+    }
+
+    int consecutiveFailures = 0;
+    const int maxConsecutiveFailures = 20;
+    int framesProcessed = 0;
+
+    while (running_.load()) {
+        DWORD streamIndex = 0;
+        DWORD flags = 0;
+        LONGLONG timeStamp = 0;
+        IMFSample* sample = nullptr;
+
+        HRESULT hr = sourceReader_->ReadSample(
+            MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+            0,
+            &streamIndex,
+            &flags,
+            &timeStamp,
+            &sample
+        );
+
+        if (FAILED(hr)) {
+            qCWarning(log_multimedia_backend) << "ReadSample failed:" << Qt::hex << hr;
+            consecutiveFailures++;
+            if (consecutiveFailures >= maxConsecutiveFailures) {
+                emit captureError("Too many consecutive read failures");
+                emit deviceDisconnected();
+                break;
+            }
+            msleep(10);
+            continue;
+        }
+
+        if (flags & MF_SOURCE_READERF_ENDOFSTREAM) {
+            qCInfo(log_multimedia_backend) << "End of stream reached";
+            break;
+        }
+
+        if (flags & MF_SOURCE_READERF_STREAMTICK) {
+            qCDebug(log_multimedia_backend) << "Stream tick received (gap in stream)";
+            continue;
+        }
+
+        if (!sample) {
+            consecutiveFailures++;
+            continue;
+        }
+
+        consecutiveFailures = 0;
+
+        // Get the first buffer from the sample
+        IMFMediaBuffer* buffer = nullptr;
+        hr = sample->GetBufferByIndex(0, &buffer);
+        if (SUCCEEDED(hr) && buffer) {
+            BYTE* data = nullptr;
+            DWORD maxLength = 0;
+            DWORD currentLength = 0;
+
+            hr = buffer->Lock(&data, &maxLength, &currentLength);
+            if (SUCCEEDED(hr) && data && currentLength > 0) {
+                QImage image = frameProcessor_->processFrame(data, currentLength);
+                if (!image.isNull()) {
+                    emit frameReady(image);
+                    framesProcessed++;
+                }
+
+                buffer->Unlock();
+            }
+
+            buffer->Release();
+        }
+
+        sample->Release();
+
+        if (framesProcessed % 60 == 0 && framesProcessed > 0) {
+            qCInfo(log_multimedia_backend) << "Frames processed:" << framesProcessed;
+        }
+    }
+
+    qCInfo(log_multimedia_backend) << "Media Foundation capture thread finished, processed"
+                                   << framesProcessed << "frames";
+#endif
+}
+
+// MfCaptureManager implementation
+
+MfCaptureManager::MfCaptureManager(QObject* parent)
+    : QObject(parent)
+    , mediaSource_(nullptr)
+    , sourceReader_(nullptr)
+    , captureThread_(nullptr)
+    , frameProcessor_(nullptr)
+    , framerate_(30)
+    , initialized_(false)
+{
+}
+
+MfCaptureManager::~MfCaptureManager()
+{
+    stopCapture();
+    cleanupMediaFoundation();
+}
+
+bool MfCaptureManager::initialize(const QString& deviceSymbolicLink, const QSize& resolution, int framerate)
+{
+#ifndef Q_OS_WIN
+    Q_UNUSED(deviceSymbolicLink);
+    Q_UNUSED(resolution);
+    Q_UNUSED(framerate);
+    qCWarning(log_multimedia_backend) << "Media Foundation is only available on Windows";
+    return false;
+#else
+    qCInfo(log_multimedia_backend) << "Initializing Media Foundation capture:"
+                                   << deviceSymbolicLink
+                                   << resolution << "@" << framerate;
+
+    resolution_ = resolution;
+    framerate_ = framerate;
+
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        qCCritical(log_multimedia_backend) << "Failed to initialize COM:" << Qt::hex << hr;
+        return false;
+    }
+
+    hr = MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to start Media Foundation:" << Qt::hex << hr;
+        CoUninitialize();
+        return false;
+    }
+
+    // Create attributes for device activation
+    IMFAttributes* attributes = nullptr;
+    hr = MFCreateAttributes(&attributes, 1);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to create attributes:" << Qt::hex << hr;
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    // Activate the media source from the symbolic link
+    IMFActivate* activate = nullptr;
+    hr = MFCreateAttributes(&attributes, 2);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to create activation attributes:" << Qt::hex << hr;
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    hr = attributes->SetGUID(
+        MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+        MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID
+    );
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to set source type:" << Qt::hex << hr;
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    hr = attributes->SetString(
+        MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
+        reinterpret_cast<const WCHAR*>(deviceSymbolicLink.utf16())
+    );
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to set symbolic link:" << Qt::hex << hr;
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    UINT32 count = 0;
+    IMFActivate** activates = nullptr;
+    hr = MFEnumDeviceSources(attributes, &activates, &count);
+    if (FAILED(hr) || count == 0) {
+        qCCritical(log_multimedia_backend) << "Failed to find device or no devices:" << Qt::hex << hr;
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    // Use the first matching device
+    hr = activates[0]->ActivateObject(IID_PPV_ARGS(&mediaSource_));
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to activate media source:" << Qt::hex << hr;
+        for (UINT32 i = 0; i < count; i++) activates[i]->Release();
+        CoTaskMemFree(activates);
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return false;
+    }
+
+    for (UINT32 i = 0; i < count; i++) activates[i]->Release();
+    CoTaskMemFree(activates);
+    attributes->Release();
+
+    // Create source reader
+    hr = MFCreateSourceReaderFromMediaSource(mediaSource_, nullptr, &sourceReader_);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to create source reader:" << Qt::hex << hr;
+        cleanupMediaFoundation();
+        return false;
+    }
+
+    // Set the native media type (resolution and format)
+    IMFMediaType* mediaType = nullptr;
+    hr = MFCreateMediaType(&mediaType);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to create media type:" << Qt::hex << hr;
+        cleanupMediaFoundation();
+        return false;
+    }
+
+    hr = mediaType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+    if (FAILED(hr)) {
+        qCCritical(log_multimedia_backend) << "Failed to set major type:" << Qt::hex << hr;
+        mediaType->Release();
+        cleanupMediaFoundation();
+        return false;
+    }
+
+    // Try NV12 first (most widely supported), then RGB24
+    GUID subtypes[] = { MFVideoFormat_NV12, MFVideoFormat_RGB24, MFVideoFormat_YUY2 };
+    bool typeSet = false;
+
+    for (const auto& subtype : subtypes) {
+        hr = mediaType->SetGUID(MF_MT_SUBTYPE, subtype);
+        if (FAILED(hr)) continue;
+
+        hr = MFSetAttributeSize(mediaType, MF_MT_FRAME_SIZE, resolution.width(), resolution.height());
+        if (FAILED(hr)) continue;
+
+        hr = MFSetAttributeRatio(mediaType, MF_MT_FRAME_RATE, framerate, 1);
+        if (FAILED(hr)) continue;
+
+        hr = MFSetAttributeRatio(mediaType, MF_MT_PIXEL_ASPECT_RATIO, 1, 1);
+        if (FAILED(hr)) continue;
+
+        hr = sourceReader_->SetCurrentMediaType(0, nullptr, mediaType);
+        if (SUCCEEDED(hr)) {
+            typeSet = true;
+            qCInfo(log_multimedia_backend) << "Media type set successfully";
+            break;
+        }
+    }
+
+    mediaType->Release();
+
+    if (!typeSet) {
+        qCCritical(log_multimedia_backend) << "Failed to set any media type";
+        cleanupMediaFoundation();
+        return false;
+    }
+
+    // Initialize frame processor with NV12 (our preferred format)
+    frameProcessor_ = new MfFrameProcessor();
+    if (!frameProcessor_->initialize(resolution.width(), resolution.height(), "NV12")) {
+        qCCritical(log_multimedia_backend) << "Failed to initialize frame processor";
+        cleanupMediaFoundation();
+        return false;
+    }
+
+    // Create capture thread
+    captureThread_ = new MfCaptureThread(this);
+    captureThread_->setSourceReader(sourceReader_);
+    captureThread_->setFrameProcessor(frameProcessor_);
+
+    initialized_ = true;
+    qCInfo(log_multimedia_backend) << "Media Foundation capture initialized successfully";
+    return true;
+#endif
+}
+
+bool MfCaptureManager::startCapture()
+{
+    if (!initialized_ || !captureThread_) {
+        qCCritical(log_multimedia_backend) << "Capture not initialized";
+        return false;
+    }
+
+    connect(captureThread_, &MfCaptureThread::frameReady,
+            this, &MfCaptureManager::frameReady);
+    connect(captureThread_, &MfCaptureThread::captureError,
+            this, &MfCaptureManager::captureError);
+    connect(captureThread_, &MfCaptureThread::deviceDisconnected,
+            this, &MfCaptureManager::deviceDisconnected);
+
+    captureThread_->setRunning(true);
+    captureThread_->start();
+
+    qCInfo(log_multimedia_backend) << "Media Foundation capture started";
+    return true;
+}
+
+void MfCaptureManager::stopCapture()
+{
+    if (captureThread_ && captureThread_->isRunning()) {
+        captureThread_->setRunning(false);
+        captureThread_->wait(3000);
+        if (captureThread_->isRunning()) {
+            captureThread_->requestInterruption();
+            captureThread_->wait(1000);
+        }
+
+        disconnect(captureThread_, nullptr, this, nullptr);
+    }
+
+    qCInfo(log_multimedia_backend) << "Media Foundation capture stopped";
+}
+
+bool MfCaptureManager::isCapturing() const
+{
+    return captureThread_ && captureThread_->isRunning();
+}
+
+void MfCaptureManager::cleanupMediaFoundation()
+{
+#ifndef Q_OS_WIN
+    return;
+#else
+    if (sourceReader_) {
+        sourceReader_->Release();
+        sourceReader_ = nullptr;
+    }
+
+    if (mediaSource_) {
+        mediaSource_->Shutdown();
+        mediaSource_->Release();
+        mediaSource_ = nullptr;
+    }
+
+    delete frameProcessor_;
+    frameProcessor_ = nullptr;
+
+    MFShutdown();
+    CoUninitialize();
+
+    initialized_ = false;
+#endif
+}

--- a/host/backend/mf/mf_capture_manager.h
+++ b/host/backend/mf/mf_capture_manager.h
@@ -1,0 +1,68 @@
+#ifndef MF_CAPTURE_MANAGER_H
+#define MF_CAPTURE_MANAGER_H
+
+#include <QObject>
+#include <QThread>
+#include <QImage>
+#include <QSize>
+#include <QString>
+#include <atomic>
+
+// Forward declarations
+struct IMFMediaSource;
+struct IMFSourceReader;
+class MfFrameProcessor;
+
+class MfCaptureThread : public QThread {
+    Q_OBJECT
+
+public:
+    explicit MfCaptureThread(QObject* parent = nullptr);
+    void setRunning(bool running);
+    void setSourceReader(IMFSourceReader* reader);
+    void setFrameProcessor(MfFrameProcessor* processor);
+
+signals:
+    void frameReady(const QImage& frame);
+    void captureError(const QString& error);
+    void deviceDisconnected();
+
+protected:
+    void run() override;
+
+private:
+    IMFSourceReader* sourceReader_;
+    MfFrameProcessor* frameProcessor_;
+    std::atomic<bool> running_;
+};
+
+class MfCaptureManager : public QObject {
+    Q_OBJECT
+
+public:
+    explicit MfCaptureManager(QObject* parent = nullptr);
+    ~MfCaptureManager();
+
+    bool initialize(const QString& deviceSymbolicLink, const QSize& resolution, int framerate);
+    bool startCapture();
+    void stopCapture();
+    bool isCapturing() const;
+
+signals:
+    void frameReady(const QImage& frame);
+    void captureError(const QString& error);
+    void deviceDisconnected();
+
+private:
+    void cleanupMediaFoundation();
+
+    IMFMediaSource* mediaSource_;
+    IMFSourceReader* sourceReader_;
+    MfCaptureThread* captureThread_;
+    MfFrameProcessor* frameProcessor_;
+    QSize resolution_;
+    int framerate_;
+    bool initialized_;
+};
+
+#endif // MF_CAPTURE_MANAGER_H

--- a/host/backend/mf/mf_device_enumerator.cpp
+++ b/host/backend/mf/mf_device_enumerator.cpp
@@ -1,0 +1,151 @@
+#include "mf_device_enumerator.h"
+
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+#pragma comment(lib, "mf.lib")
+#pragma comment(lib, "mfplat.lib")
+#pragma comment(lib, "mfuuid.lib")
+#pragma comment(lib, "ole32.lib")
+#endif
+
+#include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(log_multimedia_backend)
+
+MfDeviceEnumerator::MfDeviceEnumerator()
+{
+}
+
+MfDeviceEnumerator::~MfDeviceEnumerator()
+{
+}
+
+QList<MfDeviceInfo> MfDeviceEnumerator::enumerateVideoDevices()
+{
+    deviceList_.clear();
+
+#ifndef Q_OS_WIN
+    qCWarning(log_multimedia_backend) << "Media Foundation is only available on Windows";
+    return deviceList_;
+#else
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (FAILED(hr)) {
+        qCWarning(log_multimedia_backend) << "Failed to initialize COM for Media Foundation enumeration:" << Qt::hex << hr;
+        return deviceList_;
+    }
+
+    hr = MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET);
+    if (FAILED(hr)) {
+        qCWarning(log_multimedia_backend) << "Failed to start Media Foundation:" << Qt::hex << hr;
+        CoUninitialize();
+        return deviceList_;
+    }
+
+    IMFAttributes* attributes = nullptr;
+    hr = MFCreateAttributes(&attributes, 1);
+    if (FAILED(hr)) {
+        qCWarning(log_multimedia_backend) << "Failed to create MF attributes:" << Qt::hex << hr;
+        MFShutdown();
+        CoUninitialize();
+        return deviceList_;
+    }
+
+    hr = attributes->SetGUID(
+        MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+        MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID
+    );
+    if (FAILED(hr)) {
+        qCWarning(log_multimedia_backend) << "Failed to set video capture source type:" << Qt::hex << hr;
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return deviceList_;
+    }
+
+    IMFActivate** activateObjects = nullptr;
+    UINT32 deviceCount = 0;
+
+    hr = MFEnumDeviceSources(attributes, &activateObjects, &deviceCount);
+    if (FAILED(hr)) {
+        qCWarning(log_multimedia_backend) << "Failed to enumerate Media Foundation devices:" << Qt::hex << hr;
+        attributes->Release();
+        MFShutdown();
+        CoUninitialize();
+        return deviceList_;
+    }
+
+    qCInfo(log_multimedia_backend) << "Found" << deviceCount << "Media Foundation video capture devices";
+
+    for (UINT32 i = 0; i < deviceCount; i++) {
+        if (!activateObjects[i]) continue;
+
+        MfDeviceInfo info;
+        info.index = i;
+
+        // Get friendly name
+        wchar_t* namePtr = nullptr;
+        UINT32 nameLength = 0;
+        hr = activateObjects[i]->GetAllocatedString(
+            MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME,
+            &namePtr,
+            &nameLength
+        );
+        if (SUCCEEDED(hr) && namePtr) {
+            info.friendlyName = QString::fromWCharArray(namePtr);
+            CoTaskMemFree(namePtr);
+        } else {
+            info.friendlyName = QString("Device %1").arg(i);
+        }
+
+        // Get symbolic link (used to open the device)
+        wchar_t* linkPtr = nullptr;
+        UINT32 linkLength = 0;
+        hr = activateObjects[i]->GetAllocatedString(
+            MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
+            &linkPtr,
+            &linkLength
+        );
+        if (SUCCEEDED(hr) && linkPtr) {
+            info.symbolicLink = QString::fromWCharArray(linkPtr);
+            CoTaskMemFree(linkPtr);
+        }
+
+        qCInfo(log_multimedia_backend) << "  [" << i << "]" << info.friendlyName
+                                       << "->" << info.symbolicLink;
+
+        deviceList_.append(info);
+    }
+
+    // Free activate objects
+    for (UINT32 i = 0; i < deviceCount; i++) {
+        if (activateObjects[i]) {
+            activateObjects[i]->Release();
+        }
+    }
+    CoTaskMemFree(activateObjects);
+
+    attributes->Release();
+    MFShutdown();
+    CoUninitialize();
+
+    return deviceList_;
+#endif
+}
+
+QString MfDeviceEnumerator::getDeviceSymbolicLink(int index) const
+{
+    if (index >= 0 && index < deviceList_.size()) {
+        return deviceList_[index].symbolicLink;
+    }
+    return QString();
+}
+
+int MfDeviceEnumerator::getDeviceCount() const
+{
+    return deviceList_.size();
+}

--- a/host/backend/mf/mf_device_enumerator.h
+++ b/host/backend/mf/mf_device_enumerator.h
@@ -1,0 +1,26 @@
+#ifndef MF_DEVICE_ENUMERATOR_H
+#define MF_DEVICE_ENUMERATOR_H
+
+#include <QString>
+#include <QList>
+
+struct MfDeviceInfo {
+    QString friendlyName;
+    QString symbolicLink;
+    int index;
+};
+
+class MfDeviceEnumerator {
+public:
+    MfDeviceEnumerator();
+    ~MfDeviceEnumerator();
+
+    QList<MfDeviceInfo> enumerateVideoDevices();
+    QString getDeviceSymbolicLink(int index) const;
+    int getDeviceCount() const;
+
+private:
+    QList<MfDeviceInfo> deviceList_;
+};
+
+#endif // MF_DEVICE_ENUMERATOR_H

--- a/host/backend/mf/mf_frame_processor.cpp
+++ b/host/backend/mf/mf_frame_processor.cpp
@@ -1,0 +1,129 @@
+#include "mf_frame_processor.h"
+
+#include <QDebug>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(log_multimedia_backend)
+
+MfFrameProcessor::MfFrameProcessor()
+    : width_(0)
+    , height_(0)
+    , swsContext_(nullptr)
+    , rgbBuffer_(nullptr)
+    , rgbBufferSize_(0)
+{
+}
+
+MfFrameProcessor::~MfFrameProcessor()
+{
+    cleanup();
+}
+
+bool MfFrameProcessor::initialize(int width, int height, const QString& inputFormat)
+{
+    cleanup();
+
+    width_ = width;
+    height_ = height;
+    inputFormat_ = inputFormat;
+
+    AVPixelFormat srcFormat;
+    if (inputFormat == "NV12") {
+        srcFormat = AV_PIX_FMT_NV12;
+    } else if (inputFormat == "YUY2" || inputFormat == "YUYV") {
+        srcFormat = AV_PIX_FMT_YUYV422;
+    } else if (inputFormat == "RGB24") {
+        srcFormat = AV_PIX_FMT_RGB24;
+    } else if (inputFormat == "RGB32") {
+        srcFormat = AV_PIX_FMT_RGB32;
+    } else if (inputFormat == "MJPG" || inputFormat == "MJPEG") {
+        // MJPEG needs to be decoded first — handled separately
+        srcFormat = AV_PIX_FMT_YUV420P;
+    } else {
+        // Default to NV12 (most common MF output format)
+        srcFormat = AV_PIX_FMT_NV12;
+        qCWarning(log_multimedia_backend) << "Unknown input format:" << inputFormat
+                                          << "— defaulting to NV12";
+    }
+
+#ifdef HAVE_FFMPEG
+    swsContext_ = sws_getContext(
+        width_, height_, srcFormat,
+        width_, height_, AV_PIX_FMT_RGB24,
+        SWS_BILINEAR, nullptr, nullptr, nullptr
+    );
+
+    if (!swsContext_) {
+        qCCritical(log_multimedia_backend) << "Failed to create sws context for"
+                                           << width_ << "x" << height_ << inputFormat_;
+        return false;
+    }
+
+    rgbBufferSize_ = width_ * height_ * 3; // RGB24
+    rgbBuffer_ = new uchar[rgbBufferSize_];
+#else
+    qCCritical(log_multimedia_backend) << "FFmpeg not available for frame conversion";
+    return false;
+#endif
+
+    qCInfo(log_multimedia_backend) << "MfFrameProcessor initialized:"
+                                   << width_ << "x" << height_
+                                   << "input:" << inputFormat_;
+    return true;
+}
+
+QImage MfFrameProcessor::processFrame(const uchar* data, int dataSize)
+{
+    if (!data || !swsContext_ || dataSize <= 0) {
+        return QImage();
+    }
+
+#ifdef HAVE_FFMPEG
+    const uint8_t* srcSlice[1] = { data };
+    int srcStride[1] = { 0 };
+
+    // Calculate source stride based on format
+    if (inputFormat_ == "NV12") {
+        srcStride[0] = width_; // NV12 stride is width for Y plane
+    } else if (inputFormat_ == "YUY2" || inputFormat_ == "YUYV") {
+        srcStride[0] = width_ * 2; // YUY2 is 2 bytes per pixel
+    } else if (inputFormat_ == "RGB24") {
+        srcStride[0] = width_ * 3;
+    } else if (inputFormat_ == "RGB32") {
+        srcStride[0] = width_ * 4;
+    } else {
+        srcStride[0] = width_; // Default
+    }
+
+    uint8_t* dstSlice[1] = { rgbBuffer_ };
+    int dstStride[1] = { width_ * 3 };
+
+    sws_scale(
+        swsContext_,
+        srcSlice, srcStride,
+        0, height_,
+        dstSlice, dstStride
+    );
+
+    return QImage(rgbBuffer_, width_, height_, dstStride[0], QImage::Format_RGB888).copy();
+#else
+    Q_UNUSED(dataSize);
+    return QImage();
+#endif
+}
+
+void MfFrameProcessor::cleanup()
+{
+#ifdef HAVE_FFMPEG
+    if (swsContext_) {
+        sws_freeContext(swsContext_);
+        swsContext_ = nullptr;
+    }
+#endif
+
+    delete[] rgbBuffer_;
+    rgbBuffer_ = nullptr;
+    rgbBufferSize_ = 0;
+    width_ = 0;
+    height_ = 0;
+}

--- a/host/backend/mf/mf_frame_processor.h
+++ b/host/backend/mf/mf_frame_processor.h
@@ -1,0 +1,33 @@
+#ifndef MF_FRAME_PROCESSOR_H
+#define MF_FRAME_PROCESSOR_H
+
+#include <QImage>
+#include <QSize>
+#include <QString>
+
+#ifdef HAVE_FFMPEG
+extern "C" {
+#include <libswscale/swscale.h>
+#include <libavutil/pixfmt.h>
+}
+#endif
+
+class MfFrameProcessor {
+public:
+    MfFrameProcessor();
+    ~MfFrameProcessor();
+
+    bool initialize(int width, int height, const QString& inputFormat);
+    QImage processFrame(const uchar* data, int dataSize);
+    void cleanup();
+
+private:
+    int width_;
+    int height_;
+    QString inputFormat_;
+    SwsContext* swsContext_;
+    uchar* rgbBuffer_;
+    int rgbBufferSize_;
+};
+
+#endif // MF_FRAME_PROCESSOR_H

--- a/host/backend/mf/mfbackendhandler.cpp
+++ b/host/backend/mf/mfbackendhandler.cpp
@@ -1,0 +1,227 @@
+#include "mfbackendhandler.h"
+#include "mf_capture_manager.h"
+#include "mf_device_enumerator.h"
+#include "ui/videopane.h"
+#include "ui/globalsetting.h"
+
+#include <QLoggingCategory>
+#include <QThread>
+
+Q_DECLARE_LOGGING_CATEGORY(log_multimedia_backend)
+
+MfBackendHandler::MfBackendHandler(QObject* parent)
+    : MultimediaBackendHandler(parent)
+    , captureManager_(nullptr)
+    , deviceEnumerator_(nullptr)
+    , graphicsVideoItem_(nullptr)
+    , videoPane_(nullptr)
+    , resolution_(1920, 1080)
+    , framerate_(30)
+    , isRecording_(false)
+{
+    deviceEnumerator_ = new MfDeviceEnumerator();
+}
+
+MfBackendHandler::~MfBackendHandler()
+{
+    cleanupCamera();
+}
+
+bool MfBackendHandler::isBackendAvailable() const
+{
+#ifdef Q_OS_WIN
+    return true;
+#else
+    return false;
+#endif
+}
+
+void MfBackendHandler::setVideoOutput(QGraphicsVideoItem* videoOutput)
+{
+    disconnect(m_videoOutputConnection);
+    m_videoOutputConnection = QMetaObject::Connection{};
+
+    graphicsVideoItem_ = videoOutput;
+    videoPane_ = nullptr;
+
+    if (graphicsVideoItem_) {
+        qCWarning(log_multimedia_backend) << "QGraphicsVideoItem not supported for Media Foundation backend; use VideoPane instead";
+    }
+}
+
+void MfBackendHandler::setVideoOutput(VideoPane* videoPane)
+{
+    disconnect(m_videoOutputConnection);
+    m_videoOutputConnection = QMetaObject::Connection{};
+
+    videoPane_ = videoPane;
+    graphicsVideoItem_ = nullptr;
+
+    if (videoPane_) {
+        qCDebug(log_multimedia_backend) << "VideoPane set for Media Foundation direct rendering";
+        m_videoOutputConnection = connect(this, &MfBackendHandler::frameReadyImage,
+                videoPane_, &VideoPane::updateVideoFrameFromImage,
+                Qt::QueuedConnection);
+    }
+}
+
+void MfBackendHandler::setDevicePath(const QString& devicePath)
+{
+    devicePath_ = devicePath;
+}
+
+void MfBackendHandler::setResolution(const QSize& resolution)
+{
+    resolution_ = resolution;
+}
+
+void MfBackendHandler::setFramerate(int framerate)
+{
+    framerate_ = framerate;
+}
+
+void MfBackendHandler::startCamera()
+{
+    qCInfo(log_multimedia_backend) << "Media Foundation backend: starting camera";
+
+    if (devicePath_.isEmpty()) {
+        // Auto-select first available device
+        auto devices = deviceEnumerator_->enumerateVideoDevices();
+        if (devices.isEmpty()) {
+            emit backendError("No Media Foundation video capture devices found");
+            return;
+        }
+        deviceSymbolicLink_ = devices[0].symbolicLink;
+        qCInfo(log_multimedia_backend) << "Auto-selected device:" << devices[0].friendlyName;
+    } else if (devicePath_.startsWith("video=")) {
+        // Device path is a DirectShow-style name -- look up by friendly name
+        QString targetName = devicePath_.mid(6); // Remove "video=" prefix
+        auto devices = deviceEnumerator_->enumerateVideoDevices();
+        for (const auto& dev : devices) {
+            if (dev.friendlyName == targetName) {
+                deviceSymbolicLink_ = dev.symbolicLink;
+                qCInfo(log_multimedia_backend) << "Resolved device name to symbolic link:" << deviceSymbolicLink_;
+                break;
+            }
+        }
+        if (deviceSymbolicLink_.isEmpty()) {
+            // Fall back to using the first device
+            if (!devices.isEmpty()) {
+                deviceSymbolicLink_ = devices[0].symbolicLink;
+                qCWarning(log_multimedia_backend) << "Could not match device name, using first available device";
+            } else {
+                emit backendError("No Media Foundation devices available");
+                return;
+            }
+        }
+    } else {
+        // Assume it's already a symbolic link
+        deviceSymbolicLink_ = devicePath_;
+    }
+
+    if (!setupCaptureSession()) {
+        emit backendError("Failed to set up Media Foundation capture session");
+        return;
+    }
+
+    if (!captureManager_->startCapture()) {
+        emit backendError("Failed to start Media Foundation capture");
+        return;
+    }
+
+    qCInfo(log_multimedia_backend) << "Media Foundation camera started successfully";
+}
+
+void MfBackendHandler::stopCamera()
+{
+    qCInfo(log_multimedia_backend) << "Media Foundation backend: stopping camera";
+
+    if (captureManager_) {
+        captureManager_->stopCapture();
+    }
+}
+
+void MfBackendHandler::cleanupCamera()
+{
+    qCInfo(log_multimedia_backend) << "Media Foundation backend: cleaning up camera";
+
+    if (captureManager_) {
+        captureManager_->stopCapture();
+        captureManager_->deleteLater();
+        captureManager_ = nullptr;
+    }
+
+    disconnect(m_videoOutputConnection);
+    m_videoOutputConnection = QMetaObject::Connection{};
+    graphicsVideoItem_ = nullptr;
+    videoPane_ = nullptr;
+}
+
+bool MfBackendHandler::setupCaptureSession()
+{
+    if (captureManager_) {
+        cleanupCamera();
+    }
+
+    captureManager_ = new MfCaptureManager(this);
+
+    connect(captureManager_, &MfCaptureManager::frameReady,
+            this, &MfBackendHandler::onFrameReady);
+    connect(captureManager_, &MfCaptureManager::captureError,
+            this, &MfBackendHandler::onCaptureError);
+    connect(captureManager_, &MfCaptureManager::deviceDisconnected,
+            this, &MfBackendHandler::onDeviceDisconnected);
+
+    if (!captureManager_->initialize(deviceSymbolicLink_, resolution_, framerate_)) {
+        qCCritical(log_multimedia_backend) << "Failed to initialize capture manager";
+        return false;
+    }
+
+    return true;
+}
+
+bool MfBackendHandler::startRecording(const QString& outputPath, const QString& format, int videoBitrate)
+{
+    Q_UNUSED(outputPath);
+    Q_UNUSED(format);
+    Q_UNUSED(videoBitrate);
+    qCWarning(log_multimedia_backend) << "Recording not yet implemented for Media Foundation backend";
+    return false;
+}
+
+bool MfBackendHandler::stopRecording()
+{
+    if (isRecording_) {
+        isRecording_ = false;
+        return true;
+    }
+    return false;
+}
+
+bool MfBackendHandler::isRecording() const
+{
+    return isRecording_;
+}
+
+QStringList MfBackendHandler::getAvailableHardwareAccelerations() const
+{
+    return QStringList() << "cpu";
+}
+
+void MfBackendHandler::onFrameReady(const QImage& frame)
+{
+    emit frameReadyImage(frame);
+}
+
+void MfBackendHandler::onCaptureError(const QString& error)
+{
+    qCWarning(log_multimedia_backend) << "Media Foundation capture error:" << error;
+    emit backendError(error);
+}
+
+void MfBackendHandler::onDeviceDisconnected()
+{
+    qCWarning(log_multimedia_backend) << "Media Foundation device disconnected";
+    emit backendWarning("Device disconnected");
+    stopCamera();
+}

--- a/host/backend/mf/mfbackendhandler.h
+++ b/host/backend/mf/mfbackendhandler.h
@@ -1,0 +1,69 @@
+#ifndef MFBACKENDHANDLER_H
+#define MFBACKENDHANDLER_H
+
+#include "host/multimediabackend.h"
+#include <QMediaCaptureSession>
+#include <QGraphicsVideoItem>
+#include <QCameraFormat>
+#include <QSize>
+#include <QMetaObject>
+#include <memory>
+
+// Forward declarations
+class MfCaptureManager;
+class MfDeviceEnumerator;
+class VideoPane;
+
+class MfBackendHandler : public MultimediaBackendHandler
+{
+    Q_OBJECT
+
+public:
+    explicit MfBackendHandler(QObject* parent = nullptr);
+    ~MfBackendHandler() override;
+
+    MultimediaBackendType getBackendType() const override { return MultimediaBackendType::MediaFoundation; }
+    QString getBackendName() const override { return "Media Foundation"; }
+    bool isBackendAvailable() const override;
+
+    void startCamera() override;
+    void stopCamera() override;
+    void cleanupCamera() override;
+
+    bool startRecording(const QString& outputPath, const QString& format = "mp4", int videoBitrate = 2000000) override;
+    bool stopRecording() override;
+    bool isRecording() const override;
+
+    QStringList getAvailableHardwareAccelerations() const override;
+
+    void setVideoOutput(QGraphicsVideoItem* videoOutput);
+    void setVideoOutput(VideoPane* videoPane);
+    void setDevicePath(const QString& devicePath);
+    void setResolution(const QSize& resolution);
+    void setFramerate(int framerate);
+
+signals:
+    void frameReadyImage(const QImage& frame);
+
+private slots:
+    void onFrameReady(const QImage& frame);
+    void onCaptureError(const QString& error);
+    void onDeviceDisconnected();
+
+private:
+    bool setupCaptureSession();
+    void connectToVideoOutput();
+
+    MfCaptureManager* captureManager_;
+    MfDeviceEnumerator* deviceEnumerator_;
+    QGraphicsVideoItem* graphicsVideoItem_;
+    VideoPane* videoPane_;
+    QMetaObject::Connection m_videoOutputConnection;
+    QString devicePath_;
+    QString deviceSymbolicLink_;
+    QSize resolution_;
+    int framerate_;
+    bool isRecording_;
+};
+
+#endif // MFBACKENDHANDLER_H

--- a/host/cameramanager.cpp
+++ b/host/cameramanager.cpp
@@ -13,6 +13,10 @@
 #include "host/backend/qtbackendhandler.h"
 #include "host/backend/qtmultimediabackendhandler.h"
 
+#ifdef Q_OS_WIN
+#include "host/backend/mf/mfbackendhandler.h"
+#endif
+
 #include "ui/videopane.h"
 
 #include <QLoggingCategory>
@@ -87,6 +91,13 @@ bool CameraManager::isQtBackend() const
 {
     return m_backendHandler && m_backendHandler->getBackendType() == MultimediaBackendType::Qt;
 }
+
+#ifdef Q_OS_WIN
+bool CameraManager::isMediaFoundationBackend() const
+{
+    return m_backendHandler && m_backendHandler->getBackendType() == MultimediaBackendType::MediaFoundation;
+}
+#endif
 
 QImage CameraManager::getLatestOriginalFrame() const
 {
@@ -269,6 +280,16 @@ void CameraManager::setVideoOutput(QGraphicsVideoItem* videoOutput)
             if (gst) {
                 gst->setVideoOutput(videoOutput);
                 qDebug() << "Graphics video output successfully connected to GStreamer backend";
+            }
+        }
+#endif
+
+#ifdef Q_OS_WIN
+        if (m_backendHandler && isMediaFoundationBackend()) {
+            MfBackendHandler* mf = qobject_cast<MfBackendHandler*>(m_backendHandler.get());
+            if (mf) {
+                mf->setVideoOutput(videoOutput);
+                qDebug() << "Graphics video output successfully connected to Media Foundation backend";
             }
         }
 #endif
@@ -1602,6 +1623,53 @@ bool CameraManager::initializeCameraWithVideoOutput(VideoPane* videoPane, bool s
     }
 #endif
 
+#ifdef Q_OS_WIN
+    // Check if we're using Media Foundation backend for direct capture
+    if (isMediaFoundationBackend() && m_backendHandler) {
+        qDebug() << "Using Media Foundation backend for direct capture";
+        auto* mfHandler = qobject_cast<MfBackendHandler*>(m_backendHandler.get());
+        if (mfHandler) {
+            // Enable direct FFmpeg mode in VideoPane for rendering
+            videoPane->enableDirectFFmpegMode(true);
+
+            // Set VideoPane as Media Foundation video output for direct rendering
+            mfHandler->setVideoOutput(videoPane);
+
+            // Connect error signals
+            connect(mfHandler, &MfBackendHandler::backendError,
+                    this, [this](const QString& error) {
+                        qCWarning(log_ui_camera) << "Media Foundation backend error:" << error;
+                        emit cameraError(error);
+                    }, Qt::UniqueConnection);
+
+            // Connect camera active changed to VideoPane
+            connect(this, &CameraManager::cameraActiveChanged, videoPane, &VideoPane::onCameraActiveChanged, Qt::UniqueConnection);
+
+            // Configure resolution and framerate
+            QSize resolution(GlobalVar::instance().getCaptureWidth(), GlobalVar::instance().getCaptureHeight());
+            int framerate = GlobalVar::instance().getCaptureFps();
+            if (resolution.width() <= 0) resolution = QSize(1920, 1080);
+            if (framerate <= 0) framerate = 30;
+
+            mfHandler->setResolution(resolution);
+            mfHandler->setFramerate(framerate);
+
+            if (startCapture) {
+                qDebug() << "Starting Media Foundation direct capture with resolution:" << resolution << "framerate:" << framerate;
+                mfHandler->startCamera();
+
+                emit cameraActiveChanged(true);
+                return true;
+            } else {
+                qDebug() << "Media Foundation video pipeline set up (capture will start on demand)";
+                return true;
+            }
+        } else {
+            qCWarning(log_ui_camera) << "Failed to cast to MfBackendHandler";
+        }
+    }
+#endif
+
     // Fall back to standard Qt camera approach with QGraphicsVideoItem
     qDebug() << "Using standard Qt camera approach";
     videoPane->enableDirectFFmpegMode(false);
@@ -1667,6 +1735,15 @@ bool CameraManager::deactivateCameraByPortChain(const QString& portChain)
                 gst->setVideoOutput(m_graphicsVideoOutput);
             }
             #endif
+
+#ifdef Q_OS_WIN
+            MfBackendHandler* mf = qobject_cast<MfBackendHandler*>(m_backendHandler.get());
+            if (mf) {
+                mf->setVideoOutput(static_cast<QGraphicsVideoItem*>(nullptr));
+                QThread::msleep(50);
+                mf->setVideoOutput(m_graphicsVideoOutput);
+            }
+#endif
         }
         // Clear device info inside backend handlers
         if (m_backendHandler) {

--- a/host/cameramanager.h
+++ b/host/cameramanager.h
@@ -100,6 +100,9 @@ public:
     bool isGStreamerBackend() const;
     bool isFFmpegBackend() const;
     bool isQtBackend() const;
+#ifdef Q_OS_WIN
+    bool isMediaFoundationBackend() const;
+#endif
     
     // Camera device management and switching
     QList<QCameraDevice> getAvailableCameraDevices() const;

--- a/host/multimediabackend.cpp
+++ b/host/multimediabackend.cpp
@@ -27,6 +27,9 @@
 #endif
 #include "backend/qtbackendhandler.h"
 #include "backend/qtmultimediabackendhandler.h"
+#ifdef Q_OS_WIN
+#include "backend/mf/mfbackendhandler.h"
+#endif
 #include <QLoggingCategory>
 #include <QThread>
 #include "../ui/globalsetting.h"
@@ -225,6 +228,9 @@ MultimediaBackendType MultimediaBackendFactory::parseBackendType(const QString& 
     if (backendName.compare("ffmpeg", Qt::CaseInsensitive) == 0) {
         return MultimediaBackendType::FFmpeg;
     }
+    if (backendName.compare("mediafoundation", Qt::CaseInsensitive) == 0) {
+        return MultimediaBackendType::MediaFoundation;
+    }
     return MultimediaBackendType::Unknown;
 }
 
@@ -239,6 +245,8 @@ QString MultimediaBackendFactory::backendTypeToString(MultimediaBackendType type
             return "FFmpeg";
         case MultimediaBackendType::GStreamer:
             return "GStreamer";
+        case MultimediaBackendType::MediaFoundation:
+            return "Media Foundation";
         default:
             return "Unknown";
     }
@@ -257,6 +265,10 @@ std::unique_ptr<MultimediaBackendHandler> MultimediaBackendFactory::createHandle
             return std::make_unique<QtBackendHandler>(parent);
         case MultimediaBackendType::QtMultimedia:
             return std::make_unique<QtMultimediaBackendHandler>(parent);
+#ifdef Q_OS_WIN
+        case MultimediaBackendType::MediaFoundation:
+            return std::make_unique<MfBackendHandler>(parent);
+#endif
         default:
             qCWarning(log_multimedia_backend) << "Unknown backend type requested, falling back to FFmpeg backend.";
             return std::make_unique<FFmpegBackendHandler>(parent);

--- a/host/multimediabackend.h
+++ b/host/multimediabackend.h
@@ -40,7 +40,8 @@ enum class MultimediaBackendType {
     QtMultimedia,    // Qt's native multimedia backend (legacy)
     Qt,              // Qt's native multimedia backend (Windows)
     FFmpeg,
-    GStreamer
+    GStreamer,
+    MediaFoundation  // Windows Media Foundation capture
 };
 
 /**

--- a/main.cpp
+++ b/main.cpp
@@ -249,14 +249,36 @@ int main(int argc, char *argv[])
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_CHECK_ALWAYS_DF | _CRTDBG_LEAK_CHECK_DF);
     #endif
     qInfo() << "Start openterface...";
-    
-    // Parse command-line arguments early to check for --skip-env-check
+
+    // Parse command-line arguments early
     bool skipEnvironmentCheck = false;
+    QString overrideBackend;
+    bool listBackends = false;
+
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--skip-env-check") == 0) {
+        QString arg = QString::fromUtf8(argv[i]);
+        if (arg == "--skip-env-check") {
             skipEnvironmentCheck = true;
             qWarning() << "Skip environment check flag detected";
+        } else if (arg == "--backend" && i + 1 < argc) {
+            overrideBackend = QString::fromUtf8(argv[++i]);
+            qInfo() << "Override media backend from command line:" << overrideBackend;
+        } else if (arg == "--list-backends") {
+            listBackends = true;
         }
+    }
+
+    // List available backends and exit
+    if (listBackends) {
+        printf("Available media backends:\n");
+        printf("  ffmpeg          - FFmpeg backend (DirectShow on Windows, V4L2 on Linux)\n");
+#ifdef Q_OS_WIN
+        printf("  mediafoundation - Windows Media Foundation (native)\n");
+#else
+        printf("  gstreamer       - GStreamer backend\n");
+#endif
+        printf("  qt              - Qt Multimedia backend\n");
+        return 0;
     }
     
     setupEnv();
@@ -308,6 +330,13 @@ int main(int argc, char *argv[])
     qInfo() << "Loading settings...";
     GlobalSetting::instance().loadLogSettings();
     GlobalSetting::instance().loadVideoSettings();
+
+    // Override media backend from command line if specified
+    if (!overrideBackend.isEmpty()) {
+        GlobalSetting::instance().setMediaBackend(overrideBackend);
+        qInfo() << "Media backend overridden by command line:" << overrideBackend;
+    }
+
     applyMediaBackendSetting();
     LogHandler::instance().enableLogStore();
     

--- a/ui/globalsetting.cpp
+++ b/ui/globalsetting.cpp
@@ -107,7 +107,9 @@ void GlobalSetting::setMediaBackend(const QString &backend) {
 }
 
 QString GlobalSetting::getMediaBackend() const {
-#if defined(Q_PROCESSOR_ARM)
+#ifdef Q_OS_WIN
+    return m_settings.value("video/mediaBackend", "ffmpeg").toString();
+#elif defined(Q_PROCESSOR_ARM)
     return m_settings.value("video/mediaBackend", "gstreamer").toString();
 #else
     return m_settings.value("video/mediaBackend", "ffmpeg").toString();

--- a/ui/preferences/videopage.cpp
+++ b/ui/preferences/videopage.cpp
@@ -139,8 +139,17 @@ void VideoPage::setupUI()
 
     QComboBox *mediaBackendBox = new QComboBox();
     mediaBackendBox->setObjectName("mediaBackendBox");
+
+    // Platform-specific backend options
+#ifdef Q_OS_WIN
+    // Windows: FFmpeg (DirectShow), Media Foundation
+    mediaBackendBox->addItem("FFmpeg (DirectShow)", "ffmpeg");
+    mediaBackendBox->addItem("Media Foundation", "mediafoundation");
+#else
+    // Non-Windows: FFmpeg, GStreamer
     mediaBackendBox->addItem("FFmpeg", "ffmpeg");
     mediaBackendBox->addItem("GStreamer", "gstreamer");
+#endif
 
     // Set current backend from settings
     QString currentBackend = GlobalSetting::instance().getMediaBackend();
@@ -153,7 +162,7 @@ void VideoPage::setupUI()
     backendHintLabel->setStyleSheet("color: #666666; font-style: italic;");
     backendHintLabel->setWordWrap(true);
 
-    // GStreamer Sink Priority Setting
+    // GStreamer Sink Priority Setting (non-Windows only)
     QLabel *gstSinkLabel = new QLabel(tr("GStreamer Sink Priority: "));
     gstSinkLabel->setStyleSheet(smallLabelFontSize);
     gstSinkLabel->setObjectName("gstSinkLabel");
@@ -162,7 +171,7 @@ void VideoPage::setupUI()
     gstSinkEdit->setObjectName("gstSinkEdit");
     gstSinkEdit->setPlaceholderText("e.g. qt6videosink, xvimagesink, autovideosink");
     gstSinkEdit->setText(GlobalSetting::instance().getGStreamerSinkPriority().join(", "));
-    
+
     QLabel *gstSinkHintLabel = new QLabel(tr("Comma-separated list of sinks to try in order."));
     gstSinkHintLabel->setStyleSheet("color: #666666; font-style: italic;");
     gstSinkHintLabel->setWordWrap(true);
@@ -185,16 +194,24 @@ void VideoPage::setupUI()
     hwAccelHintLabel->setObjectName("hwAccelHintLabel");
 
     // Set initial visibility based on backend
-    bool isFFmpeg = (mediaBackendBox->currentData().toString() == "ffmpeg");
-    bool isGStreamer = (mediaBackendBox->currentData().toString() == "gstreamer");
-    
+    QString selectedBackend = mediaBackendBox->currentData().toString();
+    bool isFFmpeg = (selectedBackend == "ffmpeg");
+    bool isGStreamer = (selectedBackend == "gstreamer");
+
     hwAccelLabel->setVisible(isFFmpeg);
     hwAccelBox->setVisible(isFFmpeg);
     hwAccelHintLabel->setVisible(isFFmpeg);
 
+#ifndef Q_OS_WIN
     gstSinkLabel->setVisible(isGStreamer);
     gstSinkEdit->setVisible(isGStreamer);
     gstSinkHintLabel->setVisible(isGStreamer);
+#else
+    // GStreamer not available on Windows, always hide these
+    gstSinkLabel->setVisible(false);
+    gstSinkEdit->setVisible(false);
+    gstSinkHintLabel->setVisible(false);
+#endif
 
     // Populate hardware acceleration options
     if (m_cameraManager) {
@@ -724,15 +741,17 @@ void VideoPage::onMediaBackendChanged() {
         QString selectedBackend = mediaBackendBox->currentData().toString();
         GlobalSetting::instance().setMediaBackend(selectedBackend);
         qDebug() << "Media backend changed to:" << selectedBackend;
-        
+
+        // FFmpeg features (hardware acceleration) are available on all platforms
         bool isFFmpeg = (selectedBackend == "ffmpeg");
+        // GStreamer is only available on non-Windows
         bool isGStreamer = (selectedBackend == "gstreamer");
-        
+
         // Find hardware acceleration widgets
         QLabel *hwAccelLabel = this->findChild<QLabel*>("hwAccelLabel");
         QComboBox *hwAccelBox = this->findChild<QComboBox*>("hwAccelBox");
         QLabel *hwAccelHintLabel = this->findChild<QLabel*>("hwAccelHintLabel");
-        
+
         if (hwAccelLabel) hwAccelLabel->setVisible(isFFmpeg);
         if (hwAccelBox) hwAccelBox->setVisible(isFFmpeg);
         if (hwAccelHintLabel) hwAccelHintLabel->setVisible(isFFmpeg);
@@ -745,11 +764,14 @@ void VideoPage::onMediaBackendChanged() {
         if (gstSinkLabel) gstSinkLabel->setVisible(isGStreamer);
         if (gstSinkEdit) gstSinkEdit->setVisible(isGStreamer);
         if (gstSinkHintLabel) gstSinkHintLabel->setVisible(isGStreamer);
-        
-        // Show/hide GStreamer options based on selected backend
+
         if (selectedBackend == "gstreamer") {
             qDebug() << "GStreamer backend selected - using conservative frame rate handling";
             qDebug() << "Note: GStreamer may require specific frame rate ranges to avoid assertion errors";
+        } else if (selectedBackend == "mediafoundation") {
+            qDebug() << "Media Foundation backend selected - native Windows video capture";
+        } else if (selectedBackend == "ffmpeg") {
+            qDebug() << "FFmpeg backend selected - using DirectShow (Windows) or V4L2 (Linux)";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Windows Media Foundation (MF) capture backend as a new media backend option, with device enumeration, frame processing, and capture manager
- Enhance FFmpeg DirectShow support with hotplug handling and AMD GPU detection
- Integrate MF and FFmpeg backends into CameraManager and MultimediaBackend
- Fix Windows CI installer build: bundle `libssp-0.dll` (searched via filesystem fallback)

## Test plan
- [ ] Windows Installer build passes on this branch
- [ ] Verify MF backend can enumerate and capture from webcams on Windows
- [ ] Verify FFmpeg DirectShow backend still works alongside MF
- [ ] Confirm the built installer runs on a clean Windows machine (no MSYS2/MinGW installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)