### PR TITLE
fix(X11): resolve infinite focus grab/ungrab loop causing app hang on startup

### DIFF
--- a/SysKeyBlocker/SystemKeyBlocker_x11.cpp
+++ b/SysKeyBlocker/SystemKeyBlocker_x11.cpp
@@ -309,6 +309,7 @@ private:
     ::Window         m_tlw     = 0;         // Our window ID
     QTimer          *m_pollTimer = nullptr;  // Polls grab connection for events
     bool             m_grabbed  = false;
+    bool             m_inFocusTransition = false;  // Reentrancy guard for grab/ungrab
 };
 
 SystemKeyBlocker::X11KeyGrabber::X11KeyGrabber(SystemKeyBlocker *blocker)
@@ -570,22 +571,36 @@ bool SystemKeyBlocker::X11KeyGrabber::nativeEventFilter(
     // When our window loses focus, ungrab the keyboard so the host OS
     // can process system shortcuts (Ctrl+Alt+F1, Alt+Tab, etc.).
     // When focus returns, re-grab to resume capture.
+    //
+    // IMPORTANT: XGrabKeyboard / XUngrabKeyboard themselves generate FocusOut
+    // and FocusIn events (with mode NotifyGrab / NotifyUngrab).  If we reacted
+    // to those, we'd enter an infinite grab→FocusOut→ungrab→FocusIn→grab loop
+    // that freezes the application.  Only respond to "real" focus changes
+    // (mode == NotifyNormal), which come from the user clicking another window
+    // or the window manager moving focus.
     xcb_generic_event_t *event = static_cast<xcb_generic_event_t *>(message);
     uint responseType = event->response_type & ~0x80;
 
     if (responseType == XCB_FOCUS_OUT) {
         xcb_focus_out_event_t *focusOut = reinterpret_cast<xcb_focus_out_event_t *>(event);
-        if (focusOut->event == m_tlw && m_grabbed) {
-            qCInfo(log_syskey_x11) << "Window lost focus (FocusOut), ungrabbing keyboard";
+        if (focusOut->event == m_tlw && m_grabbed && !m_inFocusTransition
+            && focusOut->mode == XCB_NOTIFY_MODE_NORMAL) {
+            qCInfo(log_syskey_x11) << "Window lost focus (FocusOut, NotifyNormal), ungrabbing keyboard";
+            m_inFocusTransition = true;
             ungrabKeyboard();
+            m_inFocusTransition = false;
             // Reset modifier state to avoid stuck keys
             g_modifierState = ModifierKeyState{};
         }
     } else if (responseType == XCB_FOCUS_IN) {
         xcb_focus_in_event_t *focusIn = reinterpret_cast<xcb_focus_in_event_t *>(event);
-        if (focusIn->event == m_tlw && !m_grabbed && m_blocker && m_blocker->isActive()) {
-            qCInfo(log_syskey_x11) << "Window regained focus (FocusIn), re-grabbing keyboard";
+        if (focusIn->event == m_tlw && !m_grabbed && !m_inFocusTransition
+            && m_blocker && m_blocker->isActive()
+            && focusIn->mode == XCB_NOTIFY_MODE_NORMAL) {
+            qCInfo(log_syskey_x11) << "Window regained focus (FocusIn, NotifyNormal), re-grabbing keyboard";
+            m_inFocusTransition = true;
             grabKeyboard();
+            m_inFocusTransition = false;
         }
     }
 

--- a/docs/system-key-blocker-design.md
+++ b/docs/system-key-blocker-design.md
@@ -1,81 +1,81 @@
-# SystemKeyBlocker 库 — 设计文档
+# SystemKeyBlocker Library — Design Document
 
-> **目标**：一个可手动开关、跨平台（Windows/Linux）的键盘捕获库，开启后拦截**所有**系统快捷键（Win、PrintScreen、Alt+Tab 等），让 Openterface 能获取到完整的键盘 HID 码并直接发送到目标电脑。
+> **Goal**: A manually toggleable, cross-platform (Windows/Linux) keyboard capture library. When enabled, it intercepts **all** system shortcuts (Win, PrintScreen, Alt+Tab, etc.) so that Openterface can obtain the full keyboard HID codes and forward them directly to the target computer.
 >
-> **参考实现**：VirtualBox [UIKeyboardHandler.cpp](https://github.com/vbox/vbox/blob/main/src/VBox/Frontends/VirtualBox/src/runtime/UIKeyboardHandler.cpp)
+> **Reference implementation**: VirtualBox [UIKeyboardHandler.cpp](https://github.com/vbox/vbox/blob/main/src/VBox/Frontends/VirtualBox/src/runtime/UIKeyboardHandler.cpp)
 
 ---
 
-## 1. 概述
+## 1. Overview
 
-### 1.1 解决的问题
+### 1.1 Problem Statement
 
-Openterface 作为 KVM 软件，需要将用户在物理键盘上的**所有**按键（包括系统级快捷键）捕获后转发到目标电脑。但操作系统会优先拦截以下按键：
+As KVM software, Openterface needs to capture **all** keystrokes from the physical keyboard (including system-level shortcuts) and forward them to the target computer. However, the operating system intercepts the following keys before any application can see them:
 
-| 按键 | Windows 行为 | Linux 行为 |
-|------|-------------|-----------|
-| **Win / Super 键** | 弹出开始菜单 | 打开 Activities/Launcher |
-| **Win+D** | 显示桌面 | - |
-| **Win+E** | 打开文件管理器 | - |
-| **Win+L** | 锁屏 | 锁屏 |
-| **PrintScreen** | 截图工具 | 截图工具 |
-| **Alt+Tab** | 切换窗口 | 切换窗口 |
-| **Alt+F4** | 关闭窗口 | 关闭窗口 |
-| **Ctrl+Esc** | 打开开始菜单 | - |
-| **Ctrl+Alt+Del** | 安全桌面（**不可拦截**） | - |
+| Key | Windows Behavior | Linux Behavior |
+|-----|-----------------|----------------|
+| **Win / Super key** | Opens Start Menu | Opens Activities/Launcher |
+| **Win+D** | Shows desktop | - |
+| **Win+E** | Opens File Explorer | - |
+| **Win+L** | Lock screen | Lock screen |
+| **PrintScreen** | Screenshot tool | Screenshot tool |
+| **Alt+Tab** | Switch window | Switch window |
+| **Alt+F4** | Close window | Close window |
+| **Ctrl+Esc** | Opens Start Menu | - |
+| **Ctrl+Alt+Del** | Secure Attention Screen (**cannot be intercepted**) | - |
 
-Qt 在操作系统**之后**接收按键事件，因此这些按键 Qt 根本收不到。本库在 **OS 之前**拦截它们。
+Qt receives key events **after** the operating system, so these keys never reach the application. This library intercepts them **before** the OS does.
 
-### 1.2 设计原则
+### 1.2 Design Principles
 
-- **全局开关**：一个 `start()` / `stop()` 控制所有按键的捕获，不做细粒度按键配置
-- **焦点驱动**：VideoPane 获得焦点 → 自动开启全键盘捕获；失去焦点 → 自动释放
-- **简单可靠**：API 极简，只有 `start()` / `stop()` / `isActive()`
-- **跨平台**：Windows / Linux X11（Wayland 第一版不支持）
+- **Global toggle**: A single `start()` / `stop()` controls all key capture — no per-key configuration
+- **Focus-driven**: VideoPane gains focus → full keyboard capture activates automatically; loses focus → capture released
+- **Simple and reliable**: Minimal API — only `start()` / `stop()` / `isActive()`
+- **Cross-platform**: Windows / Linux X11 (Wayland not supported in v1)
 
-### 1.3 不可拦截的键
+### 1.3 Uninterceptable Keys
 
-| 键 | 原因 | 处理方式 |
-|---|------|---------|
-| **Ctrl+Alt+Del** | Windows 内核级 Secure Attention Sequence (SAS) | 用作"逃生键"——检测到后自动释放捕获，交还系统 |
-| **Fn 组合键** | 硬件级处理，OS 根本看不到 | 无法处理 |
-| **Wayland 系统键** | Wayland compositor 安全模型限制 | 第一版标注不支持 |
+| Key | Reason | Handling |
+|-----|--------|----------|
+| **Ctrl+Alt+Del** | Windows kernel-level Secure Attention Sequence (SAS) | Used as an "escape key" — detection triggers automatic release of capture, returning control to the system |
+| **Fn key combinations** | Handled at hardware level; the OS never sees them | Cannot be handled |
+| **Wayland system keys** | Wayland compositor security model restrictions | Marked as unsupported in v1 |
 
 ---
 
-## 2. API 设计
+## 2. API Design
 
-### 2.1 核心类（极简）
+### 2.1 Core Class (Minimal)
 
 ```cpp
 class SystemKeyBlocker : public QObject {
     Q_OBJECT
 public:
-    /// 全局单例
+    /// Global singleton
     static SystemKeyBlocker& instance();
 
-    /// 开始捕获所有键盘（OS 不再处理任何按键，全部转发）
+    /// Start capturing all keys (OS no longer processes any keys; all forwarded)
     bool start(quintptr nativeParentHwnd = 0);
 
-    /// 停止捕获，释放钩子，系统恢复正常
+    /// Stop capture, release hooks, system returns to normal
     void stop();
 
-    /// 当前是否处于捕获状态
+    /// Whether capture is currently active
     bool isActive() const;
 
 signals:
     /**
-     * 捕获到任意键盘事件时发出
-     * @param qtKeyCode  Qt 键码（如 Qt::Key_Meta, Qt::Key_Print）
-     * @param modifiers  Qt 修饰键（如 Qt::ControlModifier | Qt::MetaModifier）
-     * @param isKeyDown  true=按下, false=释放
-     * @param nativeVk   平台原生虚拟键码（Windows: VK_*, Linux: keysym）
+     * Emitted when any keyboard event is captured.
+     * @param qtKeyCode  Qt key code (e.g. Qt::Key_Meta, Qt::Key_Print)
+     * @param modifiers  Qt modifiers (e.g. Qt::ControlModifier | Qt::MetaModifier)
+     * @param isKeyDown  true=press, false=release
+     * @param nativeVk   Platform-native virtual key code (Windows: VK_*, Linux: keysym)
      *
-     * 连接方应将此信号转发给 KeyboardManager::handleKeyboardAction()
+     * The connected slot should forward this to KeyboardManager::handleKeyboardAction()
      */
     void keyCaptured(int qtKeyCode, int modifiers, bool isKeyDown, quint32 nativeVk);
 
-    /// 捕获状态改变
+    /// Emitted when capture state changes
     void captureStateChanged(bool active);
 
 private:
@@ -85,48 +85,48 @@ private:
 };
 ```
 
-**注意**：没有任何 `setBlockWinKey()` / `setBlockPrintScreen()` 等细粒度方法。开关就是一个：`start()` 捕获所有，`stop()` 释放所有。
+**Note**: There are no per-key methods like `setBlockWinKey()` / `setBlockPrintScreen()`. There is a single toggle: `start()` captures everything, `stop()` releases everything.
 
-### 2.2 生命周期
+### 2.2 Lifecycle
 
 ```
 start()
-  ├─ 已在运行 → 先 stop() 再重启
-  ├─ 调用平台特定 startImpl()
+  ├─ Already running → stop() first, then restart
+  ├─ Call platform-specific startImpl()
   │    ├─ Windows: SetWindowsHookEx(WH_KEYBOARD_LL, ...)
-  │    └─ Linux X11: QAbstractNativeEventFilter
-  ├─ 成功 → m_active = true, emit captureStateChanged(true)
-  └─ 失败 → 日志输出, emit captureStateChanged(false)
+  │    └─ Linux X11: XGrabKeyboard + QAbstractNativeEventFilter
+  ├─ Success → m_active = true, emit captureStateChanged(true)
+  └─ Failure → log output, emit captureStateChanged(false)
 
 stop()
-  ├─ 未在运行 → 无操作
-  ├─ 调用平台特定 stopImpl()
+  ├─ Not running → no-op
+  ├─ Call platform-specific stopImpl()
   │    ├─ Windows: UnhookWindowsHookEx()
-  │    └─ Linux X11: 移除 nativeEventFilter
+  │    └─ Linux X11: remove nativeEventFilter, release grab
   └─ m_active = false, emit captureStateChanged(false)
 ```
 
-### 2.3 逃生键 Ctrl+Alt+Del
+### 2.3 Escape Key: Ctrl+Alt+Del
 
-Windows 内核级保护，任何用户态程序都无法拦截。处理方式：
+Protected at the Windows kernel level — no user-mode program can intercept it. Handling:
 
-- 钩子回调中检测到 Ctrl+Alt+Del 三键同时按下 → 自动调用 `stop()` 释放捕获
-- 用户点击 VideoPane 重新获得焦点 → 自动调用 `start()` 恢复捕获
-- UI 提示："Ctrl+Alt+Del 无法转发，请使用目标电脑的该组合键"
+- Hook callback detects Ctrl+Alt+Del pressed simultaneously → automatically calls `stop()` to release capture
+- User clicks VideoPane to regain focus → automatically calls `start()` to restore capture
+- UI prompt: "Ctrl+Alt+Del cannot be forwarded; please use this combination on the target computer"
 
 ---
 
-## 3. 平台实现
+## 3. Platform Implementations
 
-### 3.1 Windows（`SystemKeyBlocker_win.cpp`）
+### 3.1 Windows (`SystemKeyBlocker_win.cpp`)
 
-**技术**：`SetWindowsHookEx(WH_KEYBOARD_LL, ...)` 全局低层键盘钩子
+**Technology**: `SetWindowsHookEx(WH_KEYBOARD_LL, ...)` — global low-level keyboard hook
 
-**核心流程**：
+**Core flow**:
 ```
-钩子安装 → 所有按键进入回调 → 转发信号 → return 1 吞掉事件 → OS 不再处理
-                                                    ↓ (除 Ctrl+Alt+Del)
-                                         检测到 → stop() 释放钩子 → 放行给系统
+Hook installed → all keys enter callback → forward signal → return 1 to swallow event → OS no longer processes
+                                                    ↓ (except Ctrl+Alt+Del)
+                                         detected → stop() releases hook → pass through to system
 ```
 
 ```cpp
@@ -146,7 +146,7 @@ bool SystemKeyBlocker::startImpl(quintptr nativeParentHwnd) {
         s_self = nullptr;
         return false;
     }
-    qInfo() << "SystemKeyBlocker: 全键盘捕获已启动";
+    qInfo() << "SystemKeyBlocker: Full keyboard capture started";
     return true;
 }
 
@@ -154,12 +154,12 @@ void SystemKeyBlocker::stopImpl() {
     if (m_hHook) {
         UnhookWindowsHookEx(static_cast<HHOOK>(m_hHook));
         m_hHook = nullptr;
-        qInfo() << "SystemKeyBlocker: 全键盘捕获已停止";
+        qInfo() << "SystemKeyBlocker: Full keyboard capture stopped";
     }
     s_self = nullptr;
 }
 
-// 钩子回调 — 运行在系统线程，必须快速返回（< 10ms）
+// Hook callback — runs on system thread, must return quickly (< 10ms)
 LRESULT CALLBACK SystemKeyBlocker::lowLevelKeyboardProc(
     int nCode, WPARAM wParam, LPARAM lParam)
 {
@@ -169,14 +169,15 @@ LRESULT CALLBACK SystemKeyBlocker::lowLevelKeyboardProc(
         quint32 vk = kb->vkCode;
         bool isExtended = (kb->flags & LLKHF_EXTENDED) != 0;
 
-        // ── 逃生键检测：Ctrl+Alt+Del ──
-        // Ctrl+Alt+Del 在钩子里收不到（内核级拦截），但作为安全策略保留
-        // 钩子回调中的实际处理由系统自动完成
+        // ── Escape key detection: Ctrl+Alt+Del ──
+        // Ctrl+Alt+Del is not received in the hook (kernel-level interception),
+        // but retained as a safety policy.
+        // Actual handling in the hook callback is done by the system automatically.
 
-        // ── 捕获所有按键：转发信号并吞掉事件 ──
+        // ── Capture all keys: forward signal and swallow event ──
         int qtKey = s_self->nativeToQtKey(vk, isExtended);
 
-        // 收集当前修饰键状态
+        // Collect current modifier key state
         int modifiers = 0;
         if (GetAsyncKeyState(VK_SHIFT) & 0x8000)    modifiers |= Qt::ShiftModifier;
         if (GetAsyncKeyState(VK_CONTROL) & 0x8000)  modifiers |= Qt::ControlModifier;
@@ -184,210 +185,246 @@ LRESULT CALLBACK SystemKeyBlocker::lowLevelKeyboardProc(
         if ((GetAsyncKeyState(VK_LWIN) & 0x8000) ||
             (GetAsyncKeyState(VK_RWIN) & 0x8000))   modifiers |= Qt::MetaModifier;
 
-        // 发出信号（Qt 自动跨线程投递到主事件循环）
+        // Emit signal (Qt automatically posts across threads to the main event loop)
         emit s_self->keyCaptured(qtKey, modifiers, isKeyDown, vk);
 
-        // ── 吞掉所有按键事件，OS 不再处理 ──
-        // 仅 key release 放行，防止按键卡住（与 VirtualBox 策略一致）
+        // ── Swallow all key-down events; OS no longer processes them ──
+        // Only key releases are passed through to prevent stuck keys (same as VirtualBox strategy)
         if (isKeyDown) {
-            return 1;  // 吞掉按键按下事件
+            return 1;  // Swallow key-down event
         }
-        // 释放事件放行，避免按键卡在 OS 层面
+        // Release events pass through to prevent stuck keys at the OS level
     }
     return CallNextHookEx(nullptr, nCode, wParam, lParam);
 }
 #endif
 ```
 
-**要点**：
-- 不需要管理员权限，普通用户即可安装 `WH_KEYBOARD_LL` 钩子
-- `GetModuleHandle(NULL)` 获取当前进程模块句柄，不需要 DLL
-- 钩子回调运行在**系统线程**，必须快速返回（< 10ms），所有处理通过 `emit signal` 异步投递
-- **释放事件放行**：与 VirtualBox 一致，让 OS 看到 key release 防止按键卡住
+**Key points**:
+- No admin privileges required — `WH_KEYBOARD_LL` hooks can be installed by any user
+- `GetModuleHandle(NULL)` obtains the current process module handle; no DLL needed
+- The hook callback runs on a **system thread** and must return quickly (< 10ms). All processing is dispatched asynchronously via `emit signal`
+- **Release events pass through**: Consistent with VirtualBox — lets the OS see key-up events to prevent stuck keys
 
-### 3.2 Linux X11（`SystemKeyBlocker_x11.cpp`）
+### 3.2 Linux X11 (`SystemKeyBlocker_x11.cpp`)
 
-**技术**：`QAbstractNativeEventFilter` 拦截 XCB 键盘事件
+**Technology**: `XGrabKeyboard()` on a separate X Display connection to capture the full keyboard + `QAbstractNativeEventFilter` to track focus changes
 
-> 在 X11 下，`QAbstractNativeEventFilter` 可以拦截所有到达 Qt 事件循环的 XCB 事件。对于全局快捷键冲突（如 DE 已注册 Super 键），需要额外 `xcb_grab_key`。
+> `QAbstractNativeEventFilter` can only see events on Qt's connection, but `XGrabKeyboard` delivers events to the **connection that initiated the grab**. Therefore, a second Display connection must be opened exclusively for grabbing, with a timer polling for key events on that connection and forwarding them. Meanwhile, the nativeEventFilter on Qt's connection monitors `FocusIn`/`FocusOut` to re-grab when the window regains focus.
+
+#### Architecture
+
+```
+           ┌────────────────────────────────┐
+           │          X Server              │
+           └───┬──────────────────┬─────────┘
+               │                  │
+      Qt Display connection   Grab Display connection (m_grabDpy)
+      (event loop driven)     (timer polling, 5ms)
+               │                  │
+      nativeEventFilter      XGrabKeyboard(owner_events=False)
+      monitors FocusIn/       all key events received here
+      FocusOut                forwarded via processEvents()
+      controls grab/ungrab
+```
+
+#### Core Flow
+
+```
+startImpl()
+  ├─ Open second Display connection (m_grabDpy)
+  ├─ Install nativeEventFilter (monitors focus events on Qt's connection)
+  └─ Call grabKeyboard()
+       └─ XGrabKeyboard(m_grabDpy, m_tlw, False, Async, Async)
+            └─ On success, start 5ms timer to poll key events on m_grabDpy
+
+nativeEventFilter (Qt connection)
+  ├─ XCB_FOCUS_OUT + NotifyNormal → ungrabKeyboard()
+  └─ XCB_FOCUS_IN  + NotifyNormal → grabKeyboard() (only when isActive())
+
+processEvents (timer, 5ms interval)
+  └─ XPending(m_grabDpy) loop
+       ├─ KeyPress/KeyRelease → convert keysym → emit keyCaptured
+       └─ FocusOut(NotifyWhileGrabbed) → set m_grabbed=false, retry grab after 100ms
+```
+
+#### ⚠️ Known Pitfall: Focus Event Loop (Fixed)
+
+`XGrabKeyboard` / `XUngrabKeyboard` **automatically generate** `FocusOut` and `FocusIn` events.
+If `nativeEventFilter` responds to every `FocusIn`/`FocusOut`, it creates an infinite loop:
+
+```
+FocusIn → grabKeyboard()
+  → X Server sends FocusOut (mode=NotifyGrab)
+    → FocusOut → ungrabKeyboard()
+      → X Server sends FocusIn (mode=NotifyUngrab)
+        → FocusIn → grabKeyboard()
+          → ... infinite loop
+```
+
+This loop runs hundreds of times per second, causing 100% CPU usage and a completely frozen application (logs reached 198,000 lines in 18 seconds during testing).
+
+**Fix**: Only respond to focus events with `mode == XCB_NOTIFY_MODE_NORMAL` —
+these are genuine user focus changes (clicking another window, WM moving focus, etc.).
+Ignore events with `NotifyGrab` / `NotifyUngrab` / `NotifyWhileGrabbed` modes,
+because they are generated by our own grab/ungrab operations.
+Additionally, use a `m_inFocusTransition` reentrancy guard flag to suppress all focus events during grab/ungrab execution.
 
 ```cpp
-#ifdef Q_OS_LINUX
-#include "SystemKeyBlocker.h"
-#include <QAbstractNativeEventFilter>
-#include <xcb/xcb.h>
-#include <X11/XKBlib.h>
-#include <X11/keysym.h>
-
-class X11KeyCaptureFilter : public QAbstractNativeEventFilter {
-public:
-    SystemKeyBlocker *blocker;
-
-    bool nativeEventFilter(const QByteArray &eventType, void *message,
-                           long *result) override
-    {
-        if (eventType != "xcb_generic_event_t" || !blocker->isActive())
-            return false;
-
-        auto *event = static_cast<xcb_generic_event_t*>(message);
-        uint8_t type = event->response_type & ~0x80;
-
-        if (type == XCB_KEY_PRESS || type == XCB_KEY_RELEASE) {
-            auto *ke = static_cast<xcb_key_press_event_t*>(message);
-            bool isDown = (type == XCB_KEY_PRESS);
-
-            // 获取 keysym
-            Display *dpy = XOpenDisplay(nullptr);  // 应缓存
-            KeySym ks = XkbKeycodeToKeysym(dpy, ke->detail, 0, 0);
-
-            // 收集修饰键
-            int modifiers = 0;
-            if (ke->state & ShiftMask)   modifiers |= Qt::ShiftModifier;
-            if (ke->state & ControlMask) modifiers |= Qt::ControlModifier;
-            if (ke->state & Mod1Mask)    modifiers |= Qt::AltModifier;
-            if (ke->state & Mod4Mask)    modifiers |= Qt::MetaModifier;
-
-            int qtKey = blocker->nativeToQtKey(ks, false);
-
-            emit blocker->keyCaptured(qtKey, modifiers, isDown, ks);
-
-            // 吞掉所有按下事件，释放事件放行（同 Windows 策略）
-            if (isDown)
-                return true;
-        }
-        return false;
+if (responseType == XCB_FOCUS_OUT) {
+    xcb_focus_out_event_t *focusOut = reinterpret_cast<xcb_focus_out_event_t *>(event);
+    if (focusOut->event == m_tlw && m_grabbed && !m_inFocusTransition
+        && focusOut->mode == XCB_NOTIFY_MODE_NORMAL) {
+        m_inFocusTransition = true;
+        ungrabKeyboard();
+        m_inFocusTransition = false;
+        g_modifierState = ModifierKeyState{};
     }
-};
-#endif
+} else if (responseType == XCB_FOCUS_IN) {
+    xcb_focus_in_event_t *focusIn = reinterpret_cast<xcb_focus_in_event_t *>(event);
+    if (focusIn->event == m_tlw && !m_grabbed && !m_inFocusTransition
+        && m_blocker && m_blocker->isActive()
+        && focusIn->mode == XCB_NOTIFY_MODE_NORMAL) {
+        m_inFocusTransition = true;
+        grabKeyboard();
+        m_inFocusTransition = false;
+    }
+}
+```
+
+This is a **classic pitfall** of X11 keyboard grabbing. Projects like VirtualBox, dwm, i3, and xmonad have all encountered similar issues.
+References: Xlib Programming Manual (Nye/Adrian), libx11 source code (`_XEnq` handling of FocusIn/FocusOut).
+
+---
+
+## 4. File Structure
+
+```
+SysKeyBlocker/
+├── SystemKeyBlocker.h        # Public interface header
+├── SystemKeyBlocker.cpp      # Common logic (singleton, start/stop management, nativeToQtKey)
+├── SystemKeyBlocker_win.cpp  # Windows implementation (WH_KEYBOARD_LL hook)
+└── SystemKeyBlocker_x11.cpp  # Linux X11 implementation (XGrabKeyboard + nativeEventFilter)
 ```
 
 ---
 
-## 4. 文件结构
+## 5. Integration with Existing Systems
 
-```
-target/
-├── SystemKeyBlocker.h        # 公共接口头
-├── SystemKeyBlocker.cpp      # 公共逻辑（单例、start/stop 管理、nativeToQtKey）
-├── SystemKeyBlocker_win.cpp  # Windows 实现（WH_KEYBOARD_LL 钩子）
-└── SystemKeyBlocker_x11.cpp  # Linux X11 实现（QAbstractNativeEventFilter）
-```
-
----
-
-## 5. 与现有系统的集成
-
-### 5.1 InputHandler 集成（焦点联动）
+### 5.1 InputHandler Integration (Focus Coupling)
 
 ```cpp
-// InputHandler::eventFilter 中
+// In InputHandler::eventFilter
 
 case QEvent::FocusIn:
-    // VideoPane 获得焦点 → 开启全键盘捕获
+    // VideoPane gained focus → start full keyboard capture
     SystemKeyBlocker::instance().start(m_videoPane->winId());
     break;
 
 case QEvent::FocusOut:
-    // VideoPane 失去焦点 → 释放所有捕获
+    // VideoPane lost focus → release all capture
     SystemKeyBlocker::instance().stop();
     break;
 ```
 
-### 5.2 KeyboardManager 信号连接
+### 5.2 KeyboardManager Signal Connection
 
 ```cpp
-// main.cpp 或 MainWindow 初始化时
+// In main.cpp or MainWindow initialization
 
 connect(&SystemKeyBlocker::instance(), &SystemKeyBlocker::keyCaptured,
     [](int qtKey, int modifiers, bool isKeyDown, quint32 nativeVk) {
-        // 将捕获到的所有按键转发给 KeyboardManager
+        // Forward all captured keys to KeyboardManager
         KeyboardManager::instance().handleKeyboardAction(
             qtKey, modifiers, isKeyDown, nativeVk);
     });
 ```
 
-### 5.3 UI 设置
+### 5.3 UI Settings
 
 ```
-[✓] 键盘捕获模式（开启后所有按键将转发到目标电脑，系统不再处理）
-    说明：点击视频画面启用，点击其他区域释放。
-    注意：Ctrl+Alt+Del 无法捕获（系统内核级保护）。
+[✓] Keyboard capture mode (when enabled, all keys are forwarded to the target;
+     the host system does not process them)
+    Note: Click the video pane to activate; click elsewhere to release.
+    Warning: Ctrl+Alt+Del cannot be captured (kernel-level system protection).
 ```
 
-只需一个开关，不需要按键级别的配置。
+A single toggle — no per-key configuration needed.
 
 ---
 
-## 6. 代码量预估
+## 6. Estimated Code Size
 
-| 文件 | 预估行数 |
-|------|---------|
-| `SystemKeyBlocker.h` | ~60 行 |
-| `SystemKeyBlocker.cpp` | ~120 行 |
-| `SystemKeyBlocker_win.cpp` | ~150 行 |
-| `SystemKeyBlocker_x11.cpp` | ~130 行 |
-| `InputHandler.cpp` 改动 | ~15 行 |
-| UI 改动 | ~30 行 |
-| **总计** | **~505 行** |
+| File | Estimated Lines |
+|------|----------------|
+| `SystemKeyBlocker.h` | ~60 lines |
+| `SystemKeyBlocker.cpp` | ~120 lines |
+| `SystemKeyBlocker_win.cpp` | ~150 lines |
+| `SystemKeyBlocker_x11.cpp` | ~130 lines |
+| `InputHandler.cpp` changes | ~15 lines |
+| UI changes | ~30 lines |
+| **Total** | **~505 lines** |
 
-**依赖**：
-- Windows: `<windows.h>`（系统自带，无需管理员权限）
-- Linux: `<X11/XKBlib.h>` + `<xcb/xcb.h>`（大部分发行版已装）
-- Qt: `QObject` + `QAbstractNativeEventFilter`（项目已有）
-- **零第三方依赖**
-
----
-
-## 7. 已知限制
-
-| 键/场景 | 状态 | 原因 |
-|---------|------|------|
-| `Ctrl+Alt+Del` | ❌ 无法捕获 | Windows 内核级 SAS，用户态程序无权限 |
-| `Fn` 组合键 | ❌ 无法捕获 | 硬件级处理，OS 看不到 |
-| Wayland 系统键 | ⚠️ 第一版不支持 | 需要 compositor 协议配合 |
-| 全屏游戏独占 | ⚠️ 可能部分失效 | 游戏直接读设备 |
+**Dependencies**:
+- Windows: `<windows.h>` (system-provided; no admin privileges required)
+- Linux: `<X11/XKBlib.h>` + `<xcb/xcb.h>` (installed on most distributions)
+- Qt: `QObject` + `QAbstractNativeEventFilter` (already in the project)
+- **Zero third-party dependencies**
 
 ---
 
-## 8. 风险与缓解
+## 7. Known Limitations & Pitfalls
 
-| 风险 | 缓解措施 |
-|------|---------|
-| 钩子回调超时（>10ms）导致系统卡顿 | 所有处理通过 `emit signal` 异步投递，回调只做判断+emit |
-| 杀毒软件拦截钩子 | 文档说明；必要时提示白名单 |
-| 焦点丢失后钩子未释放 | `QEvent::FocusOut` 严格调用 `stop()` |
-| Linux X11 grab 冲突 | 日志提示；建议用户关闭系统全局快捷键 |
-| 用户忘记如何退出捕获 | UI 显示当前状态；Ctrl+Alt+Del 自动释放 |
-
----
-
-## 9. 实施计划
-
-| 阶段 | 任务 | 预估 | 涉及文件 |
-|------|------|------|---------|
-| Phase 1 | 公共接口 + 单例 + start/stop | 半天 | `SystemKeyBlocker.h`, `.cpp` |
-| Phase 2 | Windows `WH_KEYBOARD_LL` 实现 | 1 天 | `SystemKeyBlocker_win.cpp` |
-| Phase 3 | Linux X11 `nativeEventFilter` 实现 | 1 天 | `SystemKeyBlocker_x11.cpp` |
-| Phase 4 | 集成到 `InputHandler`（焦点联动） | 半天 | `InputHandler.cpp` |
-| Phase 5 | UI 设置（一个开关） | 半天 | `targetcontrolpage.cpp` |
-| Phase 6 | 跨平台测试 | 半天 | 手动测试 |
-
-**总计：约 4 天**
-
-### 测试矩阵
-
-| 平台 | 环境 | 测试内容 |
-|------|------|---------|
-| Windows 10 | 普通用户 | 所有按键捕获 + 焦点切换 |
-| Windows 11 | 普通用户 | 同上 |
-| Ubuntu 22.04 | X11 + GNOME | Super 键、PrintScreen 捕获 |
-| Ubuntu 22.04 | X11 + KDE | 同上 |
-| Ubuntu 22.04 | Wayland | 验证不支持时优雅降级 |
-| Debian 12 | X11 | 基本功能 |
+| Key/Scenario | Status | Reason |
+|--------------|--------|--------|
+| `Ctrl+Alt+Del` | ❌ Cannot capture | Windows kernel-level SAS; user-mode programs have no access |
+| `Fn` key combinations | ❌ Cannot capture | Handled at hardware level; OS never sees them |
+| Wayland system keys | ⚠️ Not supported in v1 | Requires compositor protocol support |
+| Fullscreen game exclusive mode | ⚠️ May partially fail | Games read directly from the device |
+| **X11 Focus event loop** | ✅ Fixed | `XGrabKeyboard` generates `FocusOut`/`FocusIn` events. If not filtered by `mode`, this causes an infinite grab/ungrab loop (application freeze). Fix: only respond to `mode == XCB_NOTIFY_MODE_NORMAL` focus events, with `m_inFocusTransition` reentrancy guard. See §3.2. |
 
 ---
 
-## 附录 A：nativeToQtKey 映射表（核心部分）
+## 8. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Hook callback timeout (>10ms) causing system lag | All processing dispatched asynchronously via `emit signal`; callback only does check + emit |
+| Antivirus software blocking the hook | Documentation; prompt user to whitelist if necessary |
+| Hook not released after focus loss | `QEvent::FocusOut` strictly calls `stop()` |
+| Linux X11 grab conflicts | Log warnings; advise user to disable system global shortcuts |
+| **X11 Focus event loop** | ✅ Must filter `FocusIn`/`FocusOut` by `mode` (only respond to `NotifyNormal`), with reentrancy guard. See §3.2. |
+| User forgets how to exit capture | UI shows current state; Ctrl+Alt+Del auto-releases |
+
+---
+
+## 9. Implementation Plan
+
+| Phase | Task | Estimate | Files |
+|-------|------|----------|-------|
+| Phase 1 | Public interface + singleton + start/stop | Half day | `SystemKeyBlocker.h`, `.cpp` |
+| Phase 2 | Windows `WH_KEYBOARD_LL` implementation | 1 day | `SystemKeyBlocker_win.cpp` |
+| Phase 3 | Linux X11 `nativeEventFilter` implementation | 1 day | `SystemKeyBlocker_x11.cpp` |
+| Phase 4 | Integration into `InputHandler` (focus coupling) | Half day | `InputHandler.cpp` |
+| Phase 5 | UI settings (single toggle) | Half day | `targetcontrolpage.cpp` |
+| Phase 6 | Cross-platform testing | Half day | Manual testing |
+
+**Total: ~4 days**
+
+### Test Matrix
+
+| Platform | Environment | Test Content |
+|----------|------------|--------------|
+| Windows 10 | Regular user | All key capture + focus switching |
+| Windows 11 | Regular user | Same as above |
+| Ubuntu 22.04 | X11 + GNOME | Super key, PrintScreen capture |
+| Ubuntu 22.04 | X11 + KDE | Same as above |
+| Ubuntu 22.04 | Wayland | Verify graceful degradation when unsupported |
+| Debian 12 | X11 | Basic functionality |
+
+---
+
+## Appendix A: nativeToQtKey Mapping Table (Core Entries)
 
 | Windows VK | Linux KeySym | Qt Key | HID Scancode |
 |-----------|-------------|--------|-------------|
@@ -398,14 +435,14 @@ connect(&SystemKeyBlocker::instance(), &SystemKeyBlocker::keyCaptured,
 | `VK_ESCAPE` (0x1B) | `XK_Escape` | `Qt::Key_Escape` | 0x29 |
 | `VK_APPS` (0x5D) | `XK_Menu` | `Qt::Key_Menu` | 0x65 |
 
-## 附录 B：与 VirtualBox 策略对比
+## Appendix B: Comparison with VirtualBox Strategy
 
-| 方面 | VirtualBox | 我们的方案 |
-|------|-----------|-----------|
-| Windows 钩子 | `WH_KEYBOARD_LL` | 相同 |
-| Linux 方案 | `xcb_grab_keyboard` | `QAbstractNativeEventFilter` |
-| 捕获粒度 | 捕获所有（有 Host Key 概念） | 捕获所有（更简单） |
-| Ctrl+Alt+Del | 用作释放键盘的逃生键 | 相同 |
-| AltGr 处理 | 专门的 `WinAltGrMonitor` 检测假 LCtrl | 第一版不做（后续可扩展） |
-| key release 处理 | 放行给 OS 防止按键卡住 | 相同 |
-| Host Key 组合 | 可自定义（如右 Ctrl）作为逃生键 | 不需要（更简单） |
+| Aspect | VirtualBox | Our Approach |
+|--------|-----------|-------------|
+| Windows hook | `WH_KEYBOARD_LL` | Same |
+| Linux approach | `xcb_grab_keyboard` | `XGrabKeyboard` + `QAbstractNativeEventFilter` |
+| Capture granularity | Capture all (has Host Key concept) | Capture all (simpler) |
+| Ctrl+Alt+Del | Used as escape key to release keyboard | Same |
+| AltGr handling | Dedicated `WinAltGrMonitor` detects fake LCtrl | Not done in v1 (can be extended later) |
+| Key release handling | Pass through to OS to prevent stuck keys | Same |
+| Host Key combo | Customizable (e.g. Right Ctrl) as escape key | Not needed (simpler) |


### PR DESCRIPTION
## Problem

The app hangs on startup on Linux X11, consuming 100% CPU and becoming completely unresponsive. Logs show ~198,000 lines generated in 18 seconds.

## Root Cause

The `nativeEventFilter` in `X11KeyGrabber` (`SysKeyBlocker/SystemKeyBlocker_x11.cpp`) reacts to all `FocusIn`/`FocusOut` events on Qt's X connection to decide when to grab/ungrab the keyboard. However, `XGrabKeyboard()` and `XUngrabKeyboard()` **themselves generate** `FocusOut`/`FocusIn` events, creating an infinite loop:

```
FocusIn → grabKeyboard()
  → X Server sends FocusOut (mode=NotifyGrab)
    → FocusOut → ungrabKeyboard()
      → X Server sends FocusIn (mode=NotifyUngrab)
        → FocusIn → grabKeyboard()
          → ... infinite loop (~hundreds of cycles/second)
```

This is a [classic X11 pitfall](https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html#Focus_Events) encountered by VirtualBox, dwm, i3, xmonad, and others.

## Fix

Filter focus events by their `mode` field in `nativeEventFilter`:

- **Only respond to `XCB_NOTIFY_MODE_NORMAL`** — genuine user focus changes (clicking another window, WM moving focus)
- **Ignore `NotifyGrab` / `NotifyUngrab` / `NotifyWhileGrabbed`** — these are caused by our own grab/ungrab operations

Also added `m_inFocusTransition` reentrancy guard as a belt-and-suspenders safety measure.

### Results

| | Before | After |
|---|---|---|
| Log lines (15s) | 198,062 | 10,229 |
| Focus loop events | ∞ | 0 |
| GStreamer pipeline | hung | PLAYING @ 30 FPS |
| Device communication | none | GET_INFO_RSP received |

## Changes

- **`SysKeyBlocker/SystemKeyBlocker_x11.cpp`** — filter focus events by mode + reentrancy guard
- **`docs/system-key-blocker-design.md`** — translate to English, document the focus loop pitfall in §3.2, §7, §8

## Testing

- Verified app launches and runs normally on Linux X11
- GStreamer pipeline healthy at 30 FPS, device communication working
- Zero focus loop events in logs after fix