### PR TITLE
Fix outdated firmware-update instructions in the environment setup dialog

### DIFF
--- a/ui/advance/envdialog.cpp
+++ b/ui/advance/envdialog.cpp
@@ -759,10 +759,10 @@ bool EnvironmentSetupDialog::checkEnvironmentSetup() {
     qDebug() << "Latest firmware version: " << QString::fromStdString(latestVersion);
     qDebug() << "Firmware is latest: " << (latestFirmware == FirmwareResult::Latest ? "yes" : "no");
     
-    latestFirewareDescription ="<br>Current version: " + QString::fromStdString(version) + 
+    latestFirewareDescription ="<br>Current version: " + QString::fromStdString(version) +
     "<br>" + "Latest version: " + QString::fromStdString(latestVersion) +
-    "<br>" + "Please update driver to latest version." + 
-    "<br>" + "click OK then Advance->Firmware Update...";
+    "<br>" + "Please update the firmware to the latest version." +
+    "<br>" + "Click OK, then open File->Preferences->Video Firmware and use \"Firmware Update from Remote\".";
     qDebug() << latestFirewareDescription;
     #ifdef _WIN32
     return checkDriverInstalled() && latestFirmware == FirmwareResult::Latest;


### PR DESCRIPTION
The startup wizard still directs users to "Advance->Firmware Update...", but that menu entry was removed when firmware handling moved to the settings dialog. This points users to File->Preferences->Video Firmware instead, and says "firmware" rather than "driver", which is what is actually being updated.

Generated with [Claude Code](https://claude.com/claude-code)