### PR TITLE
Add firmware_check and firmware_update MCP tools

### DIFF
--- a/server/mcp/mcpConstants.h
+++ b/server/mcp/mcpConstants.h
@@ -65,6 +65,8 @@
 #define MCP_TOOL_VALIDATE_SCRIPT           "validate_script"
 #define MCP_TOOL_SYSTEM_STATUS             "system_status"
 #define MCP_TOOL_USB_SWITCH                "usb_switch"
+#define MCP_TOOL_FIRMWARE_CHECK            "firmware_check"
+#define MCP_TOOL_FIRMWARE_UPDATE           "firmware_update"
 
 // Default Named Pipe Name
 #define MCP_DEFAULT_PIPE_NAME "openterface-mcp"

--- a/server/mcp/mcpToolHandler.cpp
+++ b/server/mcp/mcpToolHandler.cpp
@@ -34,6 +34,7 @@
 #include "scripts/AST.h"
 #include "serial/SerialPortManager.h"
 #include "video/videohid.h"
+#include "video/firmwareoperationmanager.h"
 
 #include <QBuffer>
 #include <QJsonDocument>
@@ -309,6 +310,35 @@ QJsonArray McpToolHandler::listTools() const
         tools.append(tool);
     }
 
+    // ---- Firmware Tools ----
+    {
+        QJsonObject tool;
+        tool["name"] = MCP_TOOL_FIRMWARE_CHECK;
+        tool["description"] = "Check the video chip firmware version against the latest published release. Reports the current version, the latest version and whether an update is available. Downloads the latest firmware binary into memory as a side effect.";
+
+        QJsonObject schema;
+        schema["type"] = "object";
+        schema["properties"] = QJsonObject();
+        schema["required"] = QJsonArray();
+        tool["inputSchema"] = schema;
+        tools.append(tool);
+    }
+
+    {
+        QJsonObject tool;
+        tool["name"] = MCP_TOOL_FIRMWARE_UPDATE;
+        tool["description"] = "Update the video chip firmware to the latest published release. Stops all video/HID/serial activity, writes the firmware EEPROM and blocks until the write completes (up to 5 minutes). After success the app must be restarted and the device fully power-cycled (host USB power AND target power); video and control are dead until then.";
+
+        QJsonObject schema;
+        schema["type"] = "object";
+        QJsonObject props;
+        props["force"] = QJsonObject{{"type", "boolean"}, {"description", "Re-flash even if the device already reports the latest version (default false)"}};
+        schema["properties"] = props;
+        schema["required"] = QJsonArray();
+        tool["inputSchema"] = schema;
+        tools.append(tool);
+    }
+
     return tools;
 }
 
@@ -333,6 +363,8 @@ QJsonObject McpToolHandler::callTool(const QString& name, const QJsonObject& arg
     if (name == MCP_TOOL_VALIDATE_SCRIPT)             return toolValidateScript(arguments);
     if (name == MCP_TOOL_SYSTEM_STATUS)              return toolSystemStatus(arguments);
     if (name == MCP_TOOL_USB_SWITCH)                 return toolUsbSwitch(arguments);
+    if (name == MCP_TOOL_FIRMWARE_CHECK)             return toolFirmwareCheck(arguments);
+    if (name == MCP_TOOL_FIRMWARE_UPDATE)            return toolFirmwareUpdate(arguments);
 
     return errorResult("Unknown tool: " + name);
 }
@@ -915,6 +947,96 @@ QJsonObject McpToolHandler::toolUsbSwitch(const QJsonObject& args)
     } else {
         return errorResult("Invalid USB target: '" + target + "'. Use 'host' or 'target'.");
     }
+}
+
+// ==========================================================================
+// Firmware Tool Implementations
+// ==========================================================================
+
+QJsonObject McpToolHandler::toolFirmwareCheck(const QJsonObject& args)
+{
+    Q_UNUSED(args);
+    VideoHid& hid = VideoHid::getInstance();
+    FirmwareResult r = hid.isLatestFirmware();
+
+    QString status;
+    switch (r) {
+    case FirmwareResult::Latest:      status = "latest"; break;
+    case FirmwareResult::Upgradable:  status = "upgradable"; break;
+    case FirmwareResult::Timeout:     status = "network_timeout"; break;
+    case FirmwareResult::CheckFailed: status = "check_failed"; break;
+    default:                          status = "unknown"; break;
+    }
+
+    return textResult(QString("firmware status: %1 (current: %2, latest: %3)")
+        .arg(status,
+             QString::fromStdString(hid.getCurrentFirmwareVersion()),
+             QString::fromStdString(hid.getLatestFirmwareVersion())));
+}
+
+QJsonObject McpToolHandler::toolFirmwareUpdate(const QJsonObject& args)
+{
+    bool force = args.value("force").toBool(false);
+
+    VideoHid& hid = VideoHid::getInstance();
+    FirmwareResult r = hid.isLatestFirmware();
+    QString cur = QString::fromStdString(hid.getCurrentFirmwareVersion());
+    QString latest = QString::fromStdString(hid.getLatestFirmwareVersion());
+
+    if (r == FirmwareResult::Timeout || r == FirmwareResult::CheckFailed) {
+        return errorResult(QString("Firmware check failed (%1); no flash attempted. Current version: %2")
+            .arg(r == FirmwareResult::Timeout ? "network timeout" : "check failed", cur));
+    }
+    if (r == FirmwareResult::Latest && !force) {
+        return textResult(QString("Firmware already at latest version %1; nothing flashed. "
+            "Pass force=true to re-flash.").arg(cur));
+    }
+
+    qCInfo(log_server_mcp_tool) << "Firmware update starting:" << cur << "->" << latest;
+
+    // Same shutdown sequence as FirmwarePage::onCheckForUpdatesClicked():
+    // the EEPROM write must not compete with HID polling or serial traffic.
+    hid.stop();
+    hid.stopPollingOnly();
+    QThread::msleep(300);
+    SerialPortManager::getInstance().closePort();
+    QThread::msleep(200);
+
+    FirmwareOperationManager* mgr = hid.getFirmwareOperationManager();
+
+    QEventLoop loop;
+    bool done = false;
+    bool ok = false;
+    int lastPct = 0;
+    QMetaObject::Connection cProg = connect(mgr, &FirmwareOperationManager::progress,
+        &loop, [&lastPct](int pct) { lastPct = pct; });
+    QMetaObject::Connection cDone = connect(mgr, &FirmwareOperationManager::writeCompleted,
+        &loop, [&ok, &done, &loop](bool success) { ok = success; done = true; loop.quit(); });
+
+    QTimer timeout;
+    timeout.setSingleShot(true);
+    connect(&timeout, &QTimer::timeout, &loop, &QEventLoop::quit);
+    timeout.start(300000);
+
+    hid.loadFirmwareToEeprom();
+    if (!done)
+        loop.exec();
+
+    disconnect(cProg);
+    disconnect(cDone);
+
+    if (!done) {
+        return errorResult(QString("Firmware write TIMED OUT after 300s at %1%. "
+            "Device state unknown -- retry or investigate before power-cycling.").arg(lastPct));
+    }
+    if (!ok) {
+        return errorResult(QString("Firmware write FAILED at %1% (%2 -> %3). "
+            "Retry before power-cycling the device.").arg(lastPct).arg(cur, latest));
+    }
+    return textResult(QString("Firmware update SUCCESSFUL: %1 -> %2. "
+        "REQUIRED next steps: quit this app, power off BOTH ends of the KVM "
+        "(host USB power and target power), then re-energize the KVM before booting the target.")
+        .arg(cur, latest));
 }
 
 // ==========================================================================

--- a/server/mcp/mcpToolHandler.h
+++ b/server/mcp/mcpToolHandler.h
@@ -78,6 +78,8 @@ private:
     QJsonObject toolValidateScript(const QJsonObject& args);
     QJsonObject toolSystemStatus(const QJsonObject& args);
     QJsonObject toolUsbSwitch(const QJsonObject& args);
+    QJsonObject toolFirmwareCheck(const QJsonObject& args);
+    QJsonObject toolFirmwareUpdate(const QJsonObject& args);
 
     // --- Helpers ---
     static QJsonObject textResult(const QString& text);


### PR DESCRIPTION
This exposes the firmware-update flow through the MCP server added in #565, so headless and automated deployments can flash devices without driving the GUI dialogs.

Two new tools:

- **firmware_check** -- reports the device firmware version vs the latest published release (latest / upgradable / network_timeout / check_failed).
- **firmware_update** -- performs the update: mirrors the GUI flow in FirmwarePage::onCheckForUpdatesClicked (stops video/HID polling and the serial port, then writes the EEPROM via FirmwareOperationManager), blocks until writeCompleted fires (5-minute timeout), and reports success/failure with the version transition. An optional `force: true` argument re-flashes a device that already reports the latest version (possible because the network check always downloads the binary).

The success message tells the caller what the GUI tells the user: restart the app and fully power-cycle the device before use.

Tested on real hardware: drove `openterfaceQT --mcp-stdio` over JSON-RPC to update five Mini-KVMs (MS2109, 24090617 -> 26012113) in one unattended session on a Linux arm64 host; all five flashed cleanly on the first attempt and verified as latest after power-cycling.

Generated with [Claude Code](https://claude.com/claude-code)