### PR TITLE
fix(deb): remove bundled libs from Depends field

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,13 +4,14 @@ Section: base
 Priority: optional
 Architecture: ${ARCH}
 Maintainer: TechxArtisan <info@techxartisan.com>
-Depends: libegl1, libgles2-mesa | libgles2, libpulse0, libgstreamer1.0-0,
+Depends: libegl1, libgles2-mesa | libgles2, libpulse0,
  libv4l-0, libxkbcommon0, libwayland-client0 | libwayland-client,
- libxcb1, libx11-6, libqt6core6 (>= 6.4.0), libqt6svg6 | qt6-svg-dev,
+ libxcb1, libx11-6,
  libva2, libva-drm2, libva-x11-2, libvdpau1,
- libgl1-mesa-glx | libgl1, libglx0, libglvnd0, zlib1g, libturbojpeg0 | libturbojpeg
+ libgl1-mesa-glx | libgl1, libglx0, libglvnd0, zlib1g
 Description: OpenterfaceQT KVM Linux Edition
- A Qt6‑based KVM frontend for video capture and playback.  This package
- relies on the distribution’s Qt6, FFmpeg, VA‑API/VDPAU and GStreamer libraries
- instead of shipping its own copies; the previous approach caused conflicts
- when other programs accidentally picked up the bundled libraries.
+ A Qt6‑based KVM frontend for video capture and playback.
+ Qt6, FFmpeg, GStreamer and libturbojpeg are bundled under
+ /usr/lib/openterfaceqt/ and loaded by the launcher via LD_LIBRARY_PATH.
+ VA‑API/VDPAU driver packages from the distribution are still required
+ for hardware‑accelerated video decode.

--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -66,11 +66,6 @@ DEPENDENCIES=(
     "libva-drm.so.2|libva-drm2|VA-API DRM support|no"
     "libva-x11.so.2|libva-x11-2|VA-API X11 support|no"
     "libvdpau.so.1|libvdpau1|VDPAU for video decode acceleration|no"
-    
-    # NOTE: libturbojpeg is checked separately below (Phase 2) because the package
-    # was renamed from libturbojpeg0 to libturbojpeg on Ubuntu 24.04+.
-    # The ldconfig check here would fail on systems where the library is provided
-    # by the renamed package, so we defer to the dpkg-based either/or check.
 
     # Compression
     "libz.so.1|zlib1g|Compression library|yes"
@@ -174,10 +169,6 @@ HWACCEL_DEPS=(
     "libvdpau1"
 )
 
-# libturbojpeg0 was renamed to libturbojpeg on Ubuntu 24.04+.
-# Check for either name so the preinst works on older and newer distros.
-TURBOJPEG_DEPS=("libturbojpeg0" "libturbojpeg")
-
 COMPRESSION_DEPS=(
     "zlib1g"
     "libbz2-1.0"
@@ -192,8 +183,7 @@ FOUND_DEPS=0
 TOTAL_DEPS=0
 
 # Calculate total dependencies to check
-# Note: TURBOJPEG_DEPS is an "either/or" alternative (only one needed), so count it as 1
-TOTAL_DEPS=$((${#GRAPHICS_DEPS[@]} + ${#AUDIO_DEPS[@]} + ${#VIDEO_DEPS[@]} + ${#DISPLAY_DEPS[@]} + ${#OPENGL_DEPS[@]} + ${#QT6_PLATFORM_DEPS[@]} + ${#HWACCEL_DEPS[@]} + 1 + ${#COMPRESSION_DEPS[@]} + ${#DEBUG_DEPS[@]}))
+TOTAL_DEPS=$((${#GRAPHICS_DEPS[@]} + ${#AUDIO_DEPS[@]} + ${#VIDEO_DEPS[@]} + ${#DISPLAY_DEPS[@]} + ${#OPENGL_DEPS[@]} + ${#QT6_PLATFORM_DEPS[@]} + ${#HWACCEL_DEPS[@]} + ${#COMPRESSION_DEPS[@]} + ${#DEBUG_DEPS[@]}))
 
 echo "System dependency verification:"
 echo ""
@@ -289,33 +279,6 @@ for pkg in "${HWACCEL_DEPS[@]}"; do
     fi
 done
 
-# Check turbojpeg — libturbojpeg0 was renamed to libturbojpeg on Ubuntu 24.04+.
-# Either package satisfies the requirement; we only add to MISSING_DEPS if neither is installed.
-# Note: use dpkg-query with exact package names (the grep pattern "^ii.*name" used above
-# can false-positive on similarly-named packages like libturbojpeg0-dev).
-print_category "  JPEG Turbo Library:"
-TURBOJPEG_FOUND=0
-for pkg in "${TURBOJPEG_DEPS[@]}"; do
-    if dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "install ok installed"; then
-        echo "    ✅ $pkg"
-        FOUND_DEPS=$((FOUND_DEPS + 1))
-        TURBOJPEG_FOUND=1
-    else
-        echo "    ⚠️  $pkg (not installed)"
-    fi
-done
-if [ "$TURBOJPEG_FOUND" -eq 0 ]; then
-    # Detect the correct package name for this distro:
-    # Ubuntu 24.04+ and Debian 13+ renamed libturbojpeg0 → libturbojpeg
-    if apt-cache show libturbojpeg >/dev/null 2>&1; then
-        TURBOJPEG_PKG="libturbojpeg"
-    else
-        TURBOJPEG_PKG="libturbojpeg0"
-    fi
-    echo "    ❌ $TURBOJPEG_PKG is not installed (REQUIRED)"
-    MISSING_DEPS+=("$TURBOJPEG_PKG")
-fi
-
 # Check Compression dependencies
 print_category "  Compression Libraries:"
 for pkg in "${COMPRESSION_DEPS[@]}"; do
@@ -375,9 +338,7 @@ echo "How to fix"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
-# Build install command from Phase 2's MISSING_DEPS results (which correctly
-# handle the libturbojpeg0/libturbojpeg rename). Phase 1's MISSING_REQUIRED
-# is no longer used for the exit decision because it hardcoded old package names.
+# Build install command from Phase 2's MISSING_DEPS results.
 REQUIRED_PKGS=("${MISSING_DEPS[@]}")
 
 OPTIONAL_PKGS=()


### PR DESCRIPTION
Qt6, GStreamer, and libturbojpeg are bundled under /usr/lib/openterfaceqt/ but the control file still declared them as system dependencies, causing install failures on systems like Linux Mint 21.3 where Qt 6.2.4 is available but the package requires >= 6.4.0.

Removed from Depends:
- libqt6core6 (>= 6.4.0) → bundled as libQt6Core.so.6.6.3
- libqt6svg6 | qt6-svg-dev → bundled as libQt6Svg.so.6.6.3
- libgstreamer1.0-0 → bundled as libgstreamer-1.0.so.0.2606.0
- libturbojpeg0 | libturbojpeg → bundled as libturbojpeg.so.0.3.0

Also removed turbojpeg check from preinst (bundled libs don't need system checks).