### PR TITLE
fix(ci): skip artifact download when cache hit on Windows static builds

### DIFF
--- a/.github/workflows/windows-arm64-build.yaml
+++ b/.github/workflows/windows-arm64-build.yaml
@@ -390,6 +390,7 @@ jobs:
           pacman --noconfirm -Syuu --overwrite '*' --ignore msys2-runtime
 
       - name: Download Qt artifact (from build-qt job, if ran this run)
+        if: needs.setup-env.outputs.qt-cache-hit != 'true'
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -405,6 +406,7 @@ jobs:
           key: qt-6.6.3-msys2-clangarm64-windows-static-v3-${{ hashFiles('build-script/build-static-qt-from-source.sh') }}
 
       - name: Download FFmpeg artifact (from build-ffmpeg job, if ran this run)
+        if: needs.setup-env.outputs.ffmpeg-cache-hit != 'true'
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:

--- a/.github/workflows/windows-portable-build.yaml
+++ b/.github/workflows/windows-portable-build.yaml
@@ -371,6 +371,7 @@ jobs:
           }
 
       - name: Download Qt artifact
+        if: needs.setup-env.outputs.qt-cache-hit != 'true'
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
@@ -395,6 +396,7 @@ jobs:
           if (Test-Path "${{ env.QT_PREFIX }}") { dir "${{ env.QT_PREFIX }}" } else { echo "${{ env.QT_PREFIX }} not found" }
 
       - name: Download FFmpeg artifact
+        if: needs.setup-env.outputs.ffmpeg-cache-hit != 'true'
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:


### PR DESCRIPTION
The build-qt / build-ffmpeg jobs skip upload when Qt or FFmpeg cache hits in setup-env, but build-project unconditionally called download-artifact, emitting a red "Artifact not found" error annotation on every cache-hit run. The subsequent cache-restore step still succeeded so builds were green, but the warning was misleading.

Gate the download steps on the same cache-hit output that gates the upload steps, so the download only runs when the artifact was actually produced this run.