### PR TITLE
Let QT_LOGGING_RULES override the forced debug logging in headless MCP mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -292,8 +292,12 @@ int main(int argc, char *argv[])
         // Use offscreen platform — provides QInputMethod without needing a real display
         qputenv("QT_QPA_PLATFORM", "offscreen");
 
-        // Redirect all logging to stderr so we can see what's happening
-        qputenv("QT_LOGGING_RULES", "*.debug=true");
+        // Default to verbose logging in headless mode, but let the caller
+        // override it (e.g. QT_LOGGING_RULES='*.debug=false' to keep the
+        // per-frame decode-path debug output off the hot path).
+        if (!qEnvironmentVariableIsSet("QT_LOGGING_RULES")) {
+            qputenv("QT_LOGGING_RULES", "*.debug=true");
+        }
 
         QApplication app(argc, argv);
         qInfo() << "Starting MCP server in stdio transport mode (offscreen)...";


### PR DESCRIPTION
## What

In headless MCP mode (`--mcp-stdio`, or `--mcp-sse-port` without `--mcp-start`) `main.cpp` unconditionally does `qputenv("QT_LOGGING_RULES", "*.debug=true")`. Because that runs after the process has inherited its environment, a caller has no way to turn debug logging off — there is no CLI flag for it and the Preferences log settings are not loaded on this code path.

With the ffmpeg backend the debug categories log twice per decoded frame on the capture hot path (`Live-edge seek …` and `Using CPU decoder …`), which is hundreds of lines per second / ~20 KB/s of stderr for as long as the server runs.

## How

Keep the verbose default, but only apply it when `QT_LOGGING_RULES` is not already set. A wrapper can now start the server with e.g. `QT_LOGGING_RULES='*.debug=false'` and keep warnings/info. Behaviour is unchanged for anyone who does not set the variable.

## Testing

Linux/arm64, MS2130 Mini-KVM. Spawned with `QT_LOGGING_RULES='*.debug=false' openterfaceQT --mcp-stdio`: stderr drops from ~20 KB/s to <1 KB/s, no `[D]` lines, MCP tools (`capture_screen`, keyboard/mouse) work as before. Without the variable set, output is identical to before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)