### PR TITLE
ffmpeg backend: drop double deep copy per TurboJPEG frame; offer 10/20 fps in Video preferences

### DIFF
--- a/host/backend/ffmpeg/ffmpeg_frame_processor.cpp
+++ b/host/backend/ffmpeg/ffmpeg_frame_processor.cpp
@@ -274,12 +274,15 @@ QImage FFmpegFrameProcessor::ProcessPacketToImage(AVPacket* packet, AVCodecConte
                 // preserving fit with centering (letterboxing/pillarboxing).  Scaling to
                 // a narrow target with KeepAspectRatio would shrink the video unnecessarily.
 
-                // Update frame count and store frames
+                // Update frame count and store frames.  QImage is implicitly
+                // shared (copy-on-write), so plain assignment is enough — the
+                // same approach the FFmpeg path below already uses.  The two
+                // deep copies here cost 2 x ~6 MB of memcpy per 1080p frame.
                 frame_count_++;
                 if (frame_count_ > startup_frames_to_skip_) {
                     QMutexLocker locker(&mutex_);
-                    latest_frame_ = turbojpeg_result.copy();
-                    latest_original_frame_ = turbojpeg_result.copy();
+                    latest_frame_ = turbojpeg_result;
+                    latest_original_frame_ = turbojpeg_result;
                 }
 
                 return turbojpeg_result;

--- a/ui/preferences/videopage.cpp
+++ b/ui/preferences/videopage.cpp
@@ -359,12 +359,15 @@ void VideoPage::setupUI()
         // Add default resolution options for FFmpeg backend
         if (videoFormatBox->count() == 0) {
             // Add common resolutions as defaults when no camera formats available
-            std::set<int> defaultFps = {30, 60, 120};
+            // Include the lower rates the capture chip offers (MS2109/MS2130
+            // expose 10/20/30/50/60 per resolution): on CPU-constrained hosts
+            // a lower framerate is the cheapest way to cut decode/display load.
+            std::set<int> defaultFps = {10, 20, 30, 60, 120};
             QVariant fpsVariant = QVariant::fromValue<std::set<int>>(defaultFps);
 
-            videoFormatBox->addItem("1920x1080 [30 - 60 Hz]", fpsVariant);
-            videoFormatBox->addItem("1280x720 [30 - 60 Hz]", fpsVariant);
-            videoFormatBox->addItem("640x480 [30 - 60 Hz]", fpsVariant);
+            videoFormatBox->addItem("1920x1080 [10 - 60 Hz]", fpsVariant);
+            videoFormatBox->addItem("1280x720 [10 - 60 Hz]", fpsVariant);
+            videoFormatBox->addItem("640x480 [10 - 60 Hz]", fpsVariant);
 
             // Set default resolution
             m_currentResolution = QSize(1920, 1080);


### PR DESCRIPTION
## What

Two small, independent CPU savings for hosts where the ffmpeg backend decodes on the CPU (no NVDEC/QSV — e.g. any arm64 box):

1. **`FFmpegFrameProcessor::ProcessPacketToImage`** deep-copied every TurboJPEG-decoded frame twice (`latest_frame_ = result.copy(); latest_original_frame_ = result.copy();`) — ~12 MB of memcpy per 1080p frame on the capture thread. `QImage` is implicitly shared (copy-on-write), and the FFmpeg-decoder path a few lines further down already relies on that with a comment explaining why. Assign instead of copying. Nothing writes into the stored images in place (the next frame allocates a new `QImage`; `GetLatestFrame()`/`GetLatestOriginalFrame()` return `.copy()` to callers), so sharing is safe.

2. **Video preferences → Framerate**: with the ffmpeg backend the page skips camera format enumeration and uses a hard-coded fallback list that only offered 30/60/120. The MS2109/MS2130 capture chips also expose 10 and 20 fps at every resolution (`v4l2-ctl --list-formats-ext`), and a lower framerate is by far the cheapest way to cut load for console-monitoring use. Add 10 and 20 to the list and make the "[x - y Hz]" labels match.

## Testing

Linux/arm64 (8 cores), MS2130 at 1920x1080 MJPEG, ffmpeg backend, TurboJPEG decode:

- 60 fps → 30 fps via the preferences page took the process from ~220% to ~140% CPU (the device re-negotiates `timeperframe` live; `v4l2-ctl --get-parm` confirms 30/1, app reports 29.1 fps).
- With the copy removed, capture-thread CPU drops further and displayed frames, screenshots (`GetLatestOriginalFrame`) and MCP `capture_screen` are unchanged.
- 10 and 20 appear in the Framerate combo and apply correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)