### PR TITLE
ffmpeg backend (V4L2): bound the wait for a device's first frame instead of hanging the GUI thread

### DIFF
--- a/host/backend/ffmpeg/ffmpeg_device_manager.cpp
+++ b/host/backend/ffmpeg/ffmpeg_device_manager.cpp
@@ -416,6 +416,12 @@ bool FFmpegDeviceManager::InitializeInputStream(const QString& device_path, cons
     }
 #endif
     
+    // Make sure the device actually produces frames before the blocking open
+    // below: a dark capture chip would otherwise hang this thread in DQBUF.
+    if (!ProbeDeviceDeliversFrames(device_path, resolution, framerate)) {
+        return false;
+    }
+
     // Allocate format context
     format_context_ = avformat_alloc_context();
     if (!format_context_) {
@@ -558,6 +564,78 @@ bool FFmpegDeviceManager::InitializeInputStream(const QString& device_path, cons
     qCDebug(log_ffmpeg_backend) << "Stream info found successfully";
     
     return true;
+}
+
+bool FFmpegDeviceManager::ProbeDeviceDeliversFrames(const QString& device_path, const QSize& resolution, int framerate)
+{
+#ifdef Q_OS_WIN
+    Q_UNUSED(device_path); Q_UNUSED(resolution); Q_UNUSED(framerate);
+    return true;
+#else
+    // The blocking open path (avformat_open_input + avformat_find_stream_info on a
+    // V4L2 device opened without O_NONBLOCK) ends in VIDIOC_DQBUF, which sleeps in
+    // the kernel until a frame arrives. FFmpeg cannot poll our interrupt callback
+    // while it sleeps there, so a capture chip that produces no frames -- HDMI
+    // input dark, or the chip never initialised because the unit was powered up
+    // while the app was bound to another one -- parks the caller forever. On a
+    // device switch that caller is the GUI thread.
+    //
+    // Open the device non-blocking first: DQBUF then returns EAGAIN, and
+    // avformat_find_stream_info polls the interrupt callback between attempts,
+    // so the wait for the first frame is bounded by kProbeTimeoutMs. Then close
+    // it again; the real open below stays blocking, because the capture loop's
+    // live-edge logic relies on av_read_frame blocking until a fresh frame.
+    const AVInputFormat* inputFormat = av_find_input_format("v4l2");
+    if (!inputFormat) {
+        return true;   // the real open reports this properly
+    }
+    AVFormatContext* probe = avformat_alloc_context();
+    if (!probe) {
+        return true;
+    }
+    probe->interrupt_callback.callback = FFmpegDeviceManager::InterruptCallback;
+    probe->interrupt_callback.opaque = this;
+    probe->flags |= AVFMT_FLAG_NONBLOCK;
+
+    AVDictionary* options = nullptr;
+    av_dict_set(&options, "video_size", QString("%1x%2").arg(resolution.width()).arg(resolution.height()).toUtf8().constData(), 0);
+    av_dict_set(&options, "framerate", QString::number(framerate).toUtf8().constData(), 0);
+    av_dict_set(&options, "input_format", "mjpeg", 0);
+
+    // Dedicated interrupt window for the probe (InterruptCallback measures from
+    // operation_start_time_ against kOperationTimeoutMs; back-date accordingly).
+    const qint64 savedStart = operation_start_time_;
+    operation_start_time_ = QDateTime::currentMSecsSinceEpoch() - (kOperationTimeoutMs - kProbeTimeoutMs);
+
+    QElapsedTimer timer;
+    timer.start();
+    int ret = avformat_open_input(&probe, device_path.toUtf8().constData(), inputFormat, &options);
+    av_dict_free(&options);
+    bool delivered = false;
+    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+    if (ret >= 0) {
+        probe->probesize = 1024 * 32;
+        probe->max_analyze_duration = 0;
+        ret = avformat_find_stream_info(probe, nullptr);
+        delivered = (ret >= 0);
+        avformat_close_input(&probe);
+    }
+    // (on open failure avformat_open_input has already freed the context)
+    if (ret < 0) {
+        av_strerror(ret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+    }
+    operation_start_time_ = savedStart;
+
+    if (!delivered) {
+        qCCritical(log_ffmpeg_backend) << "Capture device" << device_path << "delivered no frames within"
+                                       << timer.elapsed() << "ms (" << QString::fromUtf8(errbuf) << ")."
+                                       << "The video chip may be uninitialised (unit powered up while another unit was active)"
+                                       << "or the HDMI input dark. Power-cycle the unit's USB port and select it again.";
+        return false;
+    }
+    qCInfo(log_ffmpeg_backend) << "Device" << device_path << "delivered its first frame after" << timer.elapsed() << "ms (probe)";
+    return true;
+#endif
 }
 
 bool FFmpegDeviceManager::FindVideoStream()

--- a/host/backend/ffmpeg/ffmpeg_device_manager.h
+++ b/host/backend/ffmpeg/ffmpeg_device_manager.h
@@ -77,6 +77,11 @@ public:
 
 private:
     bool InitializeInputStream(const QString& device_path, const QSize& resolution, int framerate);
+    // Linux/V4L2: open the device non-blocking and wait (bounded) for its first
+    // frame before the real, blocking open. A capture chip that delivers no
+    // frames would otherwise park the caller (the GUI thread on a device
+    // switch) in an uninterruptible VIDIOC_DQBUF forever.
+    bool ProbeDeviceDeliversFrames(const QString& device_path, const QSize& resolution, int framerate);
     bool FindVideoStream();
     bool SetupDecoder(FFmpegHardwareAccelerator* hw_accelerator);
     void WarmUpHardwareDecoder();
@@ -89,6 +94,7 @@ private:
     volatile bool interrupt_requested_;
     qint64 operation_start_time_;
     static constexpr qint64 kOperationTimeoutMs = 5000;
+    static constexpr qint64 kProbeTimeoutMs = 10000;   // first-frame wait in ProbeDeviceDeliversFrames
 };
 
 #endif // FFMPEG_DEVICE_MANAGER_H


### PR DESCRIPTION
## What

Selecting a unit in **Control → Device** whose capture chip produces no frames froze the whole application: the menu never closed and the process had to be killed. Seen with two Mini-KVMs attached, after one of them was powered up while the app was bound to the other (its chip never got initialised, so it delivered nothing); a dark HDMI input on some chips does the same.

## Why

Opening a V4L2 device goes `avformat_open_input` → `avformat_find_stream_info` → `VIDIOC_DQBUF` on a **blocking** fd. With no frame coming the ioctl sleeps in the kernel, and FFmpeg cannot poll our `interrupt_callback` while it sleeps there — so the existing 5 s timeout never fires. On a device switch that caller is the GUI thread (trace: `DeviceCoordinator::onDeviceSelected → … → FFmpegDeviceManager::InitializeInputStream → avformat_find_stream_info → ioctl`, parked for minutes).

## How

`FFmpegDeviceManager::ProbeDeviceDeliversFrames()` (Linux only; no-op on Windows): before the real open, open the device with `AVFMT_FLAG_NONBLOCK` and run `avformat_find_stream_info` under a dedicated 10 s interrupt window (`kProbeTimeoutMs`, using the existing back-dating trick on `operation_start_time_`). With the fd non-blocking, `DQBUF` returns `EAGAIN` and `find_stream_info` polls the interrupt callback between attempts, so the wait for the first frame is bounded. The probe context is then closed and the real open proceeds exactly as before — it has to stay blocking, because the capture loop's live-edge logic relies on `av_read_frame` blocking until a fresh frame.

Outcome: a unit that delivers nothing fails the switch within 10 s with a message that says what to do ("power-cycle the unit's USB port and select it again"); a live unit pays one extra open per switch.

## Testing

Linux/arm64, Qt 6.8, FFmpeg 7.1.5, two MS2109S units attached at once:
- Live switches g2 ↔ g3 (repeated, including to a unit whose USB port had just been power-cycled): probe passes in **140–225 ms**, then the normal open; console, HID, MCP unaffected.
- The no-frames case that produced the original freeze was reproduced before the fix (GUI frozen for >2 min, gdb trace above). I could not recreate a truly dark unit on demand after the fix went in (every power-cycled unit now delivered frames within ~200 ms), so the timeout branch itself has not been exercised on hardware in this form; it relies on FFmpeg's documented non-blocking + interrupt-callback behaviour. Review of that branch is welcome.
- Clean build, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)