### PR TITLE
VideoHid: swap the chip implementation under the register-I/O mutex (use-after-free on device switch)

### DIFF
--- a/video/videohid.cpp
+++ b/video/videohid.cpp
@@ -8,6 +8,7 @@
 #include <QThread>
 #include <QLoggingCategory>
 #include <QMutexLocker>
+#include <memory>
 #include <QRegularExpression>
 #include <QFile>
 #include <QFileInfo>
@@ -128,14 +129,23 @@ void VideoHid::detectChipType() {
         m_chipType = previousChipType;
     }
 
-    m_chipImpl = ChipDetector::createChip(m_chipType, this);
+    // Build the new chip object first, then swap it in under the register-I/O
+    // mutex: the polling thread runs m_chipImpl->read4Byte() under that mutex
+    // (usbXdataRead4Byte), and replacing the unique_ptr deletes the old object.
+    // Swapping unlocked was a use-after-free on every device switch taken while
+    // polling was active (SIGSEGV in Ms2109sChip::read4Byte on the poll thread).
+    std::unique_ptr<VideoChip> newChip = ChipDetector::createChip(m_chipType, this);
 
     // Wire a default no-op progress tracker for Ms2130sChip firmware writes.
     // The actual per-write callback is injected via writeEeprom() at write time.
-    if (auto* ms2130s = dynamic_cast<Ms2130sChip*>(m_chipImpl.get())) {
+    if (auto* ms2130s = dynamic_cast<Ms2130sChip*>(newChip.get())) {
         ms2130s->onChunkWritten = [this](quint32 n) {
             written_size = n;
         };
+    }
+    {
+        QMutexLocker locker(&m_registerIoMutex);
+        m_chipImpl = std::move(newChip);
     }
 
     if (!m_chipImpl)
@@ -235,7 +245,10 @@ void VideoHid::stop() {
     // Close the HID device when stopping
     endTransaction();
     // Reset chip implementation and type to force re-detection on next start
-    m_chipImpl.reset();
+    {
+        QMutexLocker locker(&m_registerIoMutex);
+        m_chipImpl.reset();
+    }
     m_chipType = VideoChipType::UNKNOWN;
     qCDebug(log_hid_device)  << "VideoHid stopped successfully and chip state cleared.";
 }


### PR DESCRIPTION
## What

With two Mini-KVMs attached, switching between them (Control → Device, or programmatically) crashed the application intermittently — twice in one afternoon here, once on the first switch. gdb on the crash:

```
Thread 43 "QThread" received signal SIGSEGV, Segmentation fault.
#0  Ms2109sChip::read4Byte(unsigned short)
#1  VideoHid::usbXdataRead4Byte(unsigned short)
#2  VideoHid::isHdmiConnected()
#3  VideoHid::pollDeviceStatus()
#4  VideoHid::PollingThread::run()
```
while the main thread was inside `DeviceCoordinator → DeviceManager::switchToDeviceByPortChainComplete → … → FFmpegDeviceManager::InitializeInputStream` (the camera part of the same switch).

## Why

`VideoHid::detectChipType()` — called on the caller's thread at the end of every successful `switchToHIDDeviceByPortChain()` — assigns `m_chipImpl` (a `std::unique_ptr<VideoChip>`), which **deletes the previous chip object**. It does so without taking `m_registerIoMutex`, while the polling thread executes `m_chipImpl->read4Byte()` under exactly that mutex in `usbXdataRead4Byte()`. Any switch taken while polling is active is therefore a use-after-free; it only shows when the poll read happens to be in flight at that instant.

## How

Build the new chip object first (`ChipDetector::detect()` performs HID I/O of its own and must stay outside the lock), then swap the pointer under `m_registerIoMutex`. The `reset()` in `stop()` takes the same lock. Two small scoped blocks; no behavioural change otherwise.

## Testing

Linux/arm64, two MS2109S units attached: a scripted reproducer of six back-to-back device switches (via MCP `device_select`, on top of PR #595's stack) plus menu switches — the unpatched build crashed with the trace above on one run; the patched build survived all runs under gdb with no signal. Being a race, absence of crashes is the best evidence available; the reasoning above is the actual argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)