### PR TITLE
VideoHid: bind HID I/O to the selected unit (transport path pinning, per-chain path cache)

### DIFF
--- a/video/transport/LinuxHIDTransport.cpp
+++ b/video/transport/LinuxHIDTransport.cpp
@@ -113,6 +113,16 @@ bool LinuxHIDTransport::getDirect(uint8_t* buf, size_t len)
 
 QString LinuxHIDTransport::getHIDDevicePath()
 {
+    // Use the device VideoHid is bound to. It decides the path once, at
+    // start() / switchToHIDDeviceByPortChain(); re-deriving it here from the
+    // global "current port chain" on every open is wrong with several units
+    // attached: that setting is rewritten by the serial/composite switch steps
+    // and, when it names no HID device, the name-based fallback below returns
+    // the FIRST capture chip -- so polling and EEPROM reads silently drifted
+    // to other units after a switch.
+    if (m_owner && !m_owner->getCurrentHIDDevicePath().isEmpty()) {
+        return m_owner->getCurrentHIDDevicePath();
+    }
     if (m_owner) {
         QString portChain = GlobalSetting::instance().getOpenterfacePortChain();
         QString hidPath = m_owner->findMatchingHIDDevice(portChain);

--- a/video/videohid.cpp
+++ b/video/videohid.cpp
@@ -410,6 +410,7 @@ void VideoHid::handleScheduledConnect()
 void VideoHid::clearDevicePathCache() {
     qCDebug(log_hid_device) << "Clearing HID device path cache";
     m_cachedDevicePath.clear();
+    m_cachedPortChain.clear();
     m_lastPathQuery = std::chrono::steady_clock::now() - std::chrono::seconds(11); // Force refresh on next call
 }
 
@@ -678,7 +679,11 @@ QString VideoHid::findMatchingHIDDevice(const QString& portChain) const
     auto now = std::chrono::steady_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - m_lastPathQuery).count();
     
-    if (!m_cachedDevicePath.isEmpty() && elapsed < 10) {
+    // The cache is only valid for the port chain it was resolved for: with
+    // several units attached a switch asked for a DIFFERENT chain within the
+    // cache window and got the previous unit's hidraw (headless --device bound
+    // to the wrong unit; rapid GUI switches likewise).
+    if (!m_cachedDevicePath.isEmpty() && m_cachedPortChain == portChain && elapsed < 10) {
         qCDebug(log_hid_device) << "Using cached HID device path:" << m_cachedDevicePath;
         return m_cachedDevicePath;
     }
@@ -734,6 +739,7 @@ QString VideoHid::findMatchingHIDDevice(const QString& portChain) const
             
             // Cache the found device path
             const_cast<VideoHid*>(this)->m_cachedDevicePath = selectedDevice.hidDevicePath;
+            const_cast<VideoHid*>(this)->m_cachedPortChain = portChain;
             
             return selectedDevice.hidDevicePath;
         }
@@ -807,6 +813,7 @@ bool VideoHid::switchToHIDDeviceByPortChain(const QString& portChain)
         clearDevicePathCache();
         
         m_cachedDevicePath = targetHIDPath;
+        m_cachedPortChain = portChain;
 
         // Re-open HID device with new path if it was previously open
         bool switchSuccess = true;

--- a/video/videohid.h
+++ b/video/videohid.h
@@ -199,6 +199,7 @@ private:
 
     // Cache for the discovered HID device path (cleared by clearDevicePathCache).
     QString m_cachedDevicePath;
+    QString m_cachedPortChain;     // port chain m_cachedDevicePath was resolved for
 
     // Polling thread used to poll device status periodically.
     class PollingThread; // forward-declared in videohid.cpp


### PR DESCRIPTION
## What

With several Mini-KVMs attached, HID traffic (status polling, EEPROM reads) did not reliably go to the unit the app had switched to. Two independent causes, both in the HID device-path resolution:

1. **`LinuxHIDTransport::getHIDDevicePath()`** re-resolved the hidraw node on *every* open from `GlobalSetting`'s current port chain. During a device switch that setting is rewritten by the serial/composite steps with chains that name no HID device, and the name-based fallback then returns the **first** capture chip found. Observed: one headless session opened `hidraw2`/`3`/`4` 43/44/45 times while bound to a single unit; `edid_info` answered with another unit's name. VideoHid already decides the path once (in `start()` / `switchToHIDDeviceByPortChain()`); the transport now opens that path, with the port-chain lookup only as the fallback before a device is bound.

2. **`VideoHid::findMatchingHIDDevice()`'s 10 s cache** returned the cached path for *any* requested port chain. A switch asked for a different chain shortly after `start()` (headless `--device` does exactly that; rapid GUI switches too) was handed the previous unit's hidraw — observed as every headless run binding to the unit of the run before it. The cache now remembers which chain it was resolved for and only answers for that chain.

## Testing

Linux/arm64, three MS2109S units attached at once. Before: headless `--device 1-4` → `BRAIN-G2-KVM`, `1-9` → `BRAIN-G3-KVM`, `1-3` → `BRAIN-G4-KVM` (rotating by one unit per run). After: `1-4` → `BRAIN-G3-KVM`, `1-9` → `BRAIN-G4-KVM`, `1-3` → `BRAIN-G2-KVM`, repeat `1-9` → `BRAIN-G4-KVM`; no HID opens on other units after the switch. GUI switching (with #597) unaffected. Clean build.

(Found while working on #594/#595; those PRs' identity cache defends against mis-attributed reads, but this is the actual cause.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)