### PR TITLE
SerialPortManager: release the closed QSerialPort immediately (use-after-free on device switch)

### DIFF
--- a/serial/SerialPortManager.cpp
+++ b/serial/SerialPortManager.cpp
@@ -1947,28 +1947,23 @@ void SerialPortManager::closePortInternal() {
                 qCWarning(log_core_serial_conn) << "Exception during serial port close";
             }
         }
-
-        // Enhanced deletion with additional safety measures
-        // Store pointer but DO NOT clear serialPort immediately to avoid race conditions
+        // Hand the object to deleteLater() and drop our pointer NOW, under the
+        // mutex we already hold. deleteLater() is itself deferred to the next
+        // event-loop iteration of this (the object's own) thread, which is all
+        // the "socket notifier" safety the old QTimer::singleShot(0) detour
+        // bought -- and that detour was a use-after-free: a port switch queues
+        // closePort() and then onSerialPortConnected(); openPort() ran before
+        // the single-shot and did `delete serialPort` on this very object, after
+        // which the single-shot called deleteLater() on freed memory. The heap
+        // corruption surfaced one switch later as a crash in QSerialPort::close().
         QObject* portPtr = serialPort;
+        serialPort = nullptr;
+        qCDebug(log_core_serial_conn) << "Deleting serial port instance:" << static_cast<void*>(portPtr);
+        portPtr->deleteLater();
 
-        // Schedule deletion for next event loop to avoid immediate socket notifier issues
-        // Use QTimer::singleShot for more reliable deferred deletion
-        QTimer::singleShot(0, this, [this, portPtr]() {
-            if (portPtr) {
-                qCDebug(log_core_serial_conn) << "Deleting serial port instance:" << static_cast<void*>(portPtr);
-                portPtr->deleteLater();
-                // Clear pointer only after scheduling deletion
-                QMutexLocker deleteLocker(&m_serialPortMutex);
-                if (serialPort == portPtr) {
-                    serialPort = nullptr;
-                    qCDebug(log_core_serial_conn) << "SerialPort instance pointer cleared";
-                }
-                // CRITICAL: Transition to CLOSED state after deletion is scheduled
-                m_portState.store(SerialPortState::CLOSED);
-                qCDebug(log_core_serial_conn) << "Port state transition: CLOSING -> CLOSED";
-            }
-        });
+        // Transition to CLOSED now that the instance is released.
+        m_portState.store(SerialPortState::CLOSED);
+        qCDebug(log_core_serial_conn) << "Port state transition: CLOSING -> CLOSED";
     } else {
         qCDebug(log_core_serial_conn) << "Serial port is not opened (serialPort is nullptr).";
         // Transition to CLOSED state even if no port instance


### PR DESCRIPTION
## What

Switching between attached Mini-KVMs crashed the app on the second switch — reproducibly with three units attached, in headless MCP mode:

```
Thread 23 "SerialWorkerThr" received signal SIGSEGV
#0  0x0000000000000020 in ?? ()
#1  QSerialPort::close()
#2  SerialPortManager::closePortInternal()
#3  SerialPortManager::closePort()::{lambda()} (queued)
```
(main thread at that moment: the camera part of the switch, `FFmpegDeviceManager::CloseDevice`).

## Why

`closePortInternal()` closed the port and then scheduled a **separate** `QTimer::singleShot(0)` that would `deleteLater()` the `QSerialPort` and clear the pointer. A device switch queues `closePort()` and right after it `onSerialPortConnected()` on the worker thread; the single-shot lands *behind* the latter, so `openPort()` runs first and does `delete serialPort` on the same object (under the mutex — the pointer was still set). The single-shot then calls `deleteLater()` on freed memory. The heap corruption surfaces on the next switch as a jump through a garbage vtable in `QSerialPort::close()`.

## How

`deleteLater()` is itself deferred to the next event-loop iteration of the object's own thread (we are on it), which is all the "socket notifier" safety the extra single-shot was meant to provide. Call it directly and clear the pointer under the mutex `closePortInternal()` already holds, so `openPort()` always finds `nullptr` and creates a fresh port. Four lines replace the single-shot block.

## Testing

Linux/arm64, three MS2109S units attached, headless instance under gdb: before — crash on the second `device_select` (two independent runs); after — nine back-to-back switches (`1-9 → 1-4 → 1-3`, ×3, 3 s apart) plus a full select/capture/type workflow across all three units, no signal. GUI switching unaffected. Clean build.

Found while working on #594/#595/#598 (device switching over MCP makes the race easy to hit); complements #597 (chip-swap race in VideoHid) and #599 (HID transport binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)