### PR TITLE
MCP keyboard_press_key: document the real modifier encoding (Qt flags, not 1/2/4/8)

### DIFF
--- a/server/mcp/mcpToolHandler.cpp
+++ b/server/mcp/mcpToolHandler.cpp
@@ -155,7 +155,7 @@ QJsonArray McpToolHandler::listTools() const
         schema["type"] = "object";
         QJsonObject props;
         props["key"] = QJsonObject{{"type", "string"}, {"description", "Qt key code (integer) or key name (string, e.g. 'A', 'Enter', 'Escape', 'Tab', 'F1', 'Control', 'Shift', 'Alt')"}};
-        props["modifiers"] = QJsonObject{{"type", "integer"}, {"description", "Modifier bitmask: 1=Shift, 2=Ctrl, 4=Alt, 8=Meta/Win"}, {"default", 0}};
+        props["modifiers"] = QJsonObject{{"type", "integer"}, {"description", "Qt::KeyboardModifiers bitfield, as KeyboardManager expects: Shift=33554432 (0x02000000), Ctrl=67108864 (0x04000000), Alt=134217728 (0x08000000), Meta/Win=268435456 (0x10000000); OR them together. (Not 1/2/4/8.)"}, {"default", 0}};
         props["isKeyDown"] = QJsonObject{{"type", "boolean"}, {"description", "true = press, false = release"}, {"default", true}};
         props["side"] = QJsonObject{{"type", "string"}, {"description", "Which side of the keyboard for modifier keys: 'left' or 'right'. Only applies to Shift, Ctrl, Alt keys."}, {"enum", QJsonArray{"left", "right"}}};
         props["autoRelease"] = QJsonObject{{"type", "boolean"}, {"description", "If true (default), auto-release the key after press. Set false to hold the key (useful for modifier combos)."}, {"default", true}};


### PR DESCRIPTION
## What

The `keyboard_press_key` tool description says `Modifier bitmask: 1=Shift, 2=Ctrl, 4=Alt, 8=Meta/Win`. The value is actually handed to `KeyboardManager::handleKeyboardAction()` unchanged, which masks it with `Qt::ShiftModifier` / `Qt::ControlModifier` / … (`0x02000000`, `0x04000000`, `0x08000000`, `0x10000000`). A client that follows the description sends modifiers that do nothing: `key=85, modifiers=2` arrives on the target as a plain `u`.

## How

Description text only — states the Qt flag values (decimal and hex) and that they are OR-ed. No behaviour change.

## Testing

Linux/arm64, MS2109S unit, target at a login prompt: `modifiers=2` → plain `u` typed; `modifiers=67108864` (Ctrl) → Ctrl+U, line cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)