### PR TITLE
MCP SSE transport: survive a client that disconnects while its session is being created (use-after-free)

### DIFF
--- a/server/mcp/mcpSseTransport.cpp
+++ b/server/mcp/mcpSseTransport.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "mcpSseTransport.h"
+#include <QTimer>
 #include "mcpProtocol.h"
 #include "mcpToolHandler.h"
 
@@ -404,14 +405,25 @@ void McpSseTransport::handleSseRequest(QTcpSocket* socket)
     }
 
     // Send the "endpoint" event — tells the client the URL to POST to.
+    // NOTE: sendSseEvent() writes and flushes; if the peer has already gone
+    // away, QTcpSocket can emit disconnected() synchronously from inside
+    // flush(), which runs onSocketDisconnected() -> cleanupSession() and
+    // removes this very session. Keep only the id across the call and look
+    // the session up again afterwards.
+    const QString sessionId = session->id;
     QJsonObject endpointData;
     endpointData["endpoint"] = QString("%1?sessionId=%2")
                                    .arg(QLatin1String(MCP_SSE_PATH_MESSAGES))
-                                   .arg(session->id);
+                                   .arg(sessionId);
     sendSseEvent(session, QStringLiteral("endpoint"), endpointData);
+    session = nullptr;
+    if (!m_sessions.contains(sessionId)) {
+        qCInfo(log_server_mcp_sse) << "SSE client went away while the session was being created:" << sessionId;
+        return;
+    }
 
-    qCInfo(log_server_mcp_sse) << "SSE session created:" << session->id;
-    emit sessionCreated(session->id);
+    qCInfo(log_server_mcp_sse) << "SSE session created:" << sessionId;
+    emit sessionCreated(sessionId);
 }
 
 // ============================================================================
@@ -488,7 +500,11 @@ void McpSseTransport::cleanupSession(const QString& sessionId)
         session->socket->disconnectFromHost();
         session->socket = nullptr;  // prevent double-close in destructor
     }
-    delete session;
+    // The session is already out of m_sessions; free it from the event loop,
+    // not here: cleanupSession() can run re-entrantly from a socket signal
+    // emitted while a caller up the stack still holds the pointer
+    // (observed: SIGSEGV in handleSseRequest() after sendSseEvent()).
+    QTimer::singleShot(0, this, [session]() { delete session; });
     emit sessionDestroyed(sessionId);
 }
 


### PR DESCRIPTION
## What

The app crashed intermittently when driven by a scripted MCP client that opens the SSE stream, issues one call and closes the stream immediately (a wrapper script doing one tool call per invocation). gdb:

```
Thread 1 "openterfaceQT" received signal SIGSEGV
#0  QDebug::putString()
#1  McpSseTransport::handleSseRequest(QTcpSocket*)
#2  McpSseTransport::onReadyRead()
```
preceded in the log by "Client disconnected, cleaning session: …" for the session just being created.

## Why

`handleSseRequest()` creates the session, calls `sendSseEvent()` for the `endpoint` event, then logs and emits `session->id`. `sendSseEvent()` writes and **flushes**; when the peer has already closed, `QTcpSocket` emits `disconnected()` synchronously from inside `flush()`, `onSocketDisconnected()` → `cleanupSession()` runs, `delete session` happens — and `handleSseRequest()` continues with a dangling pointer.

## How

- `handleSseRequest()`: keep only the id across the send and look the session up again afterwards; if it is gone, log and return.
- `cleanupSession()`: remove the session from the map immediately (as before) but free the object from the event loop (`QTimer::singleShot(0, …)`), so no caller up the stack — this one or any other path that ends in a socket signal — can be left holding freed memory.

## Testing

Linux/arm64, under gdb: 80 back-to-back open-call-close MCP sessions plus 9 device switches interleaved with calls — no failures, no signal; the new "client went away while the session was being created" branch was taken 3 times during the run (previously each of those was the crash). Clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)