### PR TITLE
Keep the capture frame-rate preference instead of the HDMI input's refresh rate

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -600,11 +600,19 @@ void MainWindow::onResolutionChange(const int& width, const int& height, const f
     GlobalVar::instance().setInputWidth(width);
     GlobalVar::instance().setInputHeight(height);
     GlobalVar::instance().setInputFps(fps);
+    // The capture resolution must follow the input signal, but the capture
+    // FRAME RATE is the user's choice (Preferences -> Video, stored as
+    // video/fps): sampling a 60 Hz input at 10 or 30 fps is exactly what a
+    // CPU-constrained or console-monitoring setup wants. This used to copy
+    // the input's refresh rate over that preference on every timing report
+    // (start-up, every device switch), so the preference never took effect.
     GlobalVar::instance().setCaptureWidth(width);
     GlobalVar::instance().setCaptureHeight(height);
-    GlobalVar::instance().setCaptureFps(fps);
+    const int captureFps = GlobalVar::instance().getCaptureFps() > 0
+                               ? GlobalVar::instance().getCaptureFps()
+                               : static_cast<int>(fps);
     m_statusBarManager->setInputResolution(width, height, fps, pixelClk);
-    m_statusBarManager->setCaptureResolution(width, height, fps);
+    m_statusBarManager->setCaptureResolution(width, height, captureFps);
     
     // No popup message for resolution changes
 }


### PR DESCRIPTION
## What

Preferences → Video → Framerate (persisted as `video/fps`) never survived a launch: the app came up capturing at the input's 60 Hz regardless of the stored 10/20/30, and switched back to 60 on every device switch.

## Why

`MainWindow::onResolutionChange()` receives the input timing from the video chip's HID interface and copied **width, height and refresh rate** into the capture settings (`GlobalVar::setCaptureFps(fps)`). The chip reports its timing at start-up and after every device switch, so the user's preference was overwritten every time. The resolution must follow the signal; the frame rate is a user choice — sampling a 60 Hz input at 10 or 30 fps is the point of that setting on CPU-constrained or console-monitoring hosts (60 → 10 fps took this app from ~220 % to ~56 % CPU here).

## How

Keep tracking input width/height; stop overwriting the capture fps; show the capture fps (not the input rate) in the status bar's capture field; fall back to the input rate only when no preference exists (`getCaptureFps() <= 0`). One function changed.

## Testing

Linux/arm64, MS2109S, `video/fps=10` stored: before — `v4l2-ctl --get-parm` 60/1 after start, ~24 fps delivered; after — 10/1 from start-up and after switching units, 9.7 fps delivered, CPU 71 % with three units attached (was far higher). Preferences page still changes the rate live as before. Clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)