### PR TITLE
fix(build): replace POSIX setenv with Qt qputenv for Windows compatibility

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -320,10 +320,9 @@ int main(int argc, char *argv[])
             // Redirect stdout to stderr
             dup2(STDERR_FILENO, STDOUT_FILENO);
             // Store saved fd for later use by MCP server
-            const char* fdStr = QString::number(savedStdout).toUtf8().constData();
+            QByteArray fdStr = QString::number(savedStdout).toUtf8();
             qCDebug(log_app_main) << "Setting OPENTERFACE_SAVED_STDOUT=" << fdStr;
-            int result = setenv("OPENTERFACE_SAVED_STDOUT", fdStr, 1);
-            qCDebug(log_app_main) << "setenv result:" << result;
+            qputenv("OPENTERFACE_SAVED_STDOUT", fdStr);
         }
 
         // Use offscreen platform — provides QInputMethod without needing a real display


### PR DESCRIPTION
## Summary
- `main.cpp:325` used POSIX `setenv()` which is not available on MinGW, causing the Windows build to fail:
  ```
  error: 'setenv' was not declared in this scope; did you mean 'getenv'?
  ```
- Replace `setenv` with Qt's cross-platform `qputenv()`, which pairs with the existing `qgetenv()` call in `mcpServer.cpp:226`.
- Also fixes a use-after-free bug: the original code stored a `const char*` from a temporary `QByteArray` (`QString::number(savedStdout).toUtf8().constData()`) that was destroyed before `setenv` could use it. The fix keeps the `QByteArray` alive in a local variable.

## Test plan
- [x] Verify Windows (MinGW) build succeeds
- [x] Verify Linux build still works (qputenv works on all platforms)
- [x] Verify MCP server stdio mode can still read `OPENTERFACE_SAVED_STDOUT` via `qgetenv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)