### PR TITLE
Fix keyboard handling (sticky keys, focus loss)

### DIFF
--- a/host/HostManager.cpp
+++ b/host/HostManager.cpp
@@ -259,6 +259,11 @@ void HostManager::handleKeyboardAction(int keyCode, int modifiers, bool isKeyDow
     }
 }
 
+void HostManager::releaseAllKeys()
+{
+    keyboardManager.releaseAllKeys();
+}
+
 void HostManager::setRepeatingKeystroke(int interval) {
     m_repeatingInterval = interval;
     if (interval > 0) {

--- a/host/HostManager.h
+++ b/host/HostManager.h
@@ -79,6 +79,7 @@ public:
     void setRepeatingKeystroke(int interval);
 
     void handleKeyboardAction(int keyCode, int modifiers, bool isKeyDown, unsigned int nativeVirtualKey = 0);
+    void releaseAllKeys();
 
     void setKeyboardLayout(const QString& layoutName);
 

--- a/target/KeyboardManager.cpp
+++ b/target/KeyboardManager.cpp
@@ -745,6 +745,29 @@ void KeyboardManager::handleKeyboardAction(int keyCode, int modifiers, bool isKe
     }
 }
 
+void KeyboardManager::releaseAllKeys()
+{
+    if (currentMappedKeyCodes.isEmpty() && currentModifiers == 0) {
+        return;
+    }
+
+    qCDebug(log_host_kb_state) << "Releasing all guest keys after focus/window loss"
+               << "pressedKeys=" << currentMappedKeyCodes.size()
+               << "modifiers=0x" << Qt::hex << currentModifiers;
+
+    // An empty keyboard report releases every regular key and modifier held by
+    // the guest, including any key whose release never reached Qt.
+    QByteArray keyData = CMD_SEND_KB_GENERAL_DATA;
+    keyData[5] = 0;
+    for (int i = 7; i < keyData.size(); ++i) {
+        keyData[i] = 0;
+    }
+    emit SerialPortManager::getInstance().sendCommandAsync(keyData, false);
+
+    currentMappedKeyCodes.clear();
+    currentModifiers = 0;
+}
+
 void KeyboardManager::handlePasteChar(int key, int modifiers){
     unsigned int control = 0x00;
     QByteArray keyData = CMD_SEND_KB_GENERAL_DATA;

--- a/target/KeyboardManager.h
+++ b/target/KeyboardManager.h
@@ -49,6 +49,7 @@ public:
     }
 
     void handleKeyboardAction(int keyCode, int modifiers, bool isKeyDown, unsigned int nativeVirtualKey = 0);
+    void releaseAllKeys();
     void handlePasteChar(int key, int modifiers);
 
     /*

--- a/ui/initializer/mainwindowinitializer.cpp
+++ b/ui/initializer/mainwindowinitializer.cpp
@@ -714,6 +714,15 @@ void MainWindowInitializer::finalize()
             &KeyboardManager::getInstance(), &KeyboardManager::handleKeyboardAction);
     qCDebug(log_ui_mainwindowinitializer) << "SystemKeyBlocker keyCaptured signal connected to HostManager";
 
+    // Release all keys on focus loss
+    connect(qApp, &QApplication::applicationStateChanged, m_mainWindow,
+            [](Qt::ApplicationState state) {
+                if (state != Qt::ApplicationActive) {
+                    qCDebug(log_ui_mainwindowinitializer) << "Application became inactive; releasing guest keys";
+                    HostManager::getInstance().releaseAllKeys();
+                }
+            });
+
     // Always install the keyboard hook when the window is shown.
     // The hook captures ALL keystrokes and forwards them to the target.
     // The SystemBlocker toggle controls whether the hook also swallows events
@@ -772,4 +781,3 @@ void MainWindowInitializer::finalize()
     
     qCDebug(log_ui_mainwindowinitializer) << "Finalization complete";
 }
-

--- a/ui/videopane.cpp
+++ b/ui/videopane.cpp
@@ -949,6 +949,13 @@ void VideoPane::keyPressEvent(QKeyEvent *event)
         m_inputHandler->handleKeyPress(event);
     }
 
+    // Tab is a guest key, not a Qt focus-navigation key.  Do not pass it to
+    // QGraphicsView, otherwise Qt may move focus away before the key release.
+    if (event->key() == Qt::Key_Tab || event->key() == Qt::Key_Backtab) {
+        event->accept();
+        return;
+    }
+
     // Handle Shift + Arrow keys for panning in zoomed mode
     if (m_scaleFactor > 1.0 && event->modifiers() == Qt::ShiftModifier) {
         // Define scroll step size (in pixels)
@@ -1612,4 +1619,3 @@ void VideoPane::startZoomHintFadeOut()
     
     fadeAnimation->start(QAbstractAnimation::DeleteWhenStopped);
 }
-


### PR DESCRIPTION
This fixes a few issues that I found with keyboard handling:

- Tab no longer stays pressed forever
- All keys are released on focus loss (should prevent 'sticky' keys)

