### PR TITLE
MCP screen_to_markdown: expose the analyzer's terminal mode

### DIFF
--- a/server/mcp/mcpToolHandler.cpp
+++ b/server/mcp/mcpToolHandler.cpp
@@ -287,12 +287,13 @@ QJsonArray McpToolHandler::listTools() const
     {
         QJsonObject tool;
         tool["name"] = MCP_TOOL_SCREEN_TO_MARKDOWN;
-        tool["description"] = "Capture the target screen and convert it to a structured Markdown representation with OCR-detected text and UI element locations. Returns coordinates (0-4096 range) for all detected elements, making it easy for AI to find buttons, menus, and interactive elements without needing vision. Requires Tesseract OCR to be installed and the feature to be enabled in Preferences -> MCP Server.";
+        tool["description"] = "Capture the target screen and convert it to a structured Markdown representation with OCR-detected text and UI element locations. Returns coordinates (0-4096 range) for all detected elements, making it easy for AI to find buttons, menus, and interactive elements without needing vision. For a text console (shell, boot log, BIOS text screen) pass mode='terminal', which reads the screen as lines of text and OCRs only the region that changed since the previous call. Requires Tesseract OCR to be installed and the feature to be enabled in Preferences -> MCP Server.";
 
         QJsonObject schema;
         schema["type"] = "object";
         QJsonObject props;
         props["detail_level"] = QJsonObject{{"type", "string"}, {"description", "Level of detail in output: 'basic' (only interactive elements) or 'detailed' (full breakdown with all text)"}, {"enum", QJsonArray{"basic", "detailed"}}, {"default", "detailed"}};
+        props["mode"] = QJsonObject{{"type", "string"}, {"description", "Analysis mode: 'general' for a graphical UI (text and UI elements with coordinates), or 'terminal' for a text console (line-oriented text, differential OCR of the changed region only). Ignored by detail_level."}, {"enum", QJsonArray{"general", "terminal"}}, {"default", "general"}};
         schema["properties"] = props;
         schema["required"] = QJsonArray();
         tool["inputSchema"] = schema;
@@ -1061,16 +1062,24 @@ QJsonObject McpToolHandler::toolScreenToMarkdown(const QJsonObject& args)
         detailLevel = "detailed";
     }
 
+    // Get analysis mode. Terminal mode reads the screen as lines of text and
+    // OCRs only the region that changed since the previous call, which suits
+    // a scrolling console far better than the general UI-element pass.
+    const QString modeStr = args.value("mode").toString("general").toLower();
+    const AnalysisMode mode = (modeStr == "terminal") ? AnalysisMode::Terminal
+                                                      : AnalysisMode::General;
+
     // Get the current frame
     QImage frame = m_cameraManager->getLatestOriginalFrame();
     if (frame.isNull()) {
         return errorResult("No frame available from camera");
     }
 
-    qCInfo(log_server_mcp_tool) << "Analyzing screen with detail level:" << detailLevel;
+    qCInfo(log_server_mcp_tool) << "Analyzing screen with detail level:" << detailLevel
+                                << "mode:" << modeStr;
 
     // Analyze the screen
-    ScreenAnalysis analysis = m_screenAnalyzer->analyzeScreen(frame, detailLevel);
+    ScreenAnalysis analysis = m_screenAnalyzer->analyzeScreen(frame, detailLevel, mode);
 
     // Return the Markdown output
     return textResult(analysis.markdownOutput);


### PR DESCRIPTION
## What

`ScreenAnalyzer::analyzeScreen()` already takes an `AnalysisMode`, and **Terminal** mode is meaningfully different from General: it reads the screen as lines of text and OCRs only the region that changed since the previous call (differential OCR with 20 px padding), instead of extracting UI elements with coordinates.

The only caller that passes it today is the AI chat panel (`ai/ChatToolExecution.cpp`, `"mode": "terminal"`). `toolScreenToMarkdown()` never passes the parameter, so every MCP client gets General mode. Watching a shell, a boot log or a BIOS text screen over MCP therefore returns a coordinate table of individual words rather than the console's lines.

This adds the same `mode` argument to the tool schema and passes it through. Default stays `"general"`, so existing clients are unaffected.

## Testing

Built with `HAVE_TESSERACT` (Tesseract 5.5.0 + Leptonica 1.84.1, `eng.traineddata`), Linux/arm64, headless SSE mode, an Openterface unit facing a Linux text console.

`mode: "terminal"` returns the console's lines:

```
# Terminal Output (1920x1080)

Debian Version trixie/sid
Linux Version 6.17.0-1029-nvidia, Compiled #29-Ubuntu SMP PREEMPT_DYNAMIC Wed Jul
20 2.81GHz ARM Unknown/Unknown Processors, 124GB RAM, 40k Bogomips
brain-cell-a3
Ubuntu 24.04.4 LTS brain-cell-a3 tty1
brain-cell-a3 login: _
```

Default (`general`, and omitting the argument) returns the previous behaviour on the same frame: a `| Text | Pixel Coords | MCP Coords | Confidence |` table of word fragments. Verified in the log that the requested mode reaches the analyzer (`Analyzing screen ... mode: Terminal` / `Using terminal OCR mode`).

Only the ASCII-art part of the boot banner OCRs poorly, which is inherent to OCR on box-drawing characters and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)