### PR TITLE
fix: statusbar improvements and Media Foundation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ tests/keyboard/*.moc
 openterfaceQT
 .qmake.stash
 Makefile
+
+# Build output directories (cmake / qmake)
+build-cmake/
+build-qmake/

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -438,7 +438,7 @@ openterfaceQT [OPTIONS]
 
 | Argument                    | Description                                                |
 |-----------------------------|------------------------------------------------------------|
-| `--backend <NAME>`          | Select media backend (`ffmpeg`, `mediafoundation`, `qt`, `gstreamer`, `qtmultimedia`). Persisted to settings. |
+| `--backend <NAME>`          | Select media backend (`ffmpeg`, `mediafoundation`, `gstreamer`). Persisted to settings. |
 | `--list-backends`           | Print available media backends for the current platform and exit. |
 | `--mcp-stdio`               | Enable stdio transport (headless mode)                     |
 | `--mcp-pipe`                | Enable Named Pipe transport mode                           |
@@ -451,7 +451,7 @@ openterfaceQT [OPTIONS]
 **Media backend notes**:
 
 - `--backend` overrides the stored preference **and** persists the choice for subsequent launches. For a one-shot override, set via Settings UI and restore afterwards, or edit the `video/mediaBackend` key in the registry/config directly.
-- On Windows, available backends are `ffmpeg` (default, DirectShow), `mediafoundation` (native Windows Media Foundation), and `qt` (Qt Multimedia). On Linux, `ffmpeg` (V4L2) and `gstreamer`.
+- On Windows, available backends are `ffmpeg` (default, DirectShow) and `mediafoundation` (native Windows Media Foundation). On Linux, `ffmpeg` (V4L2) and `gstreamer`.
 - `--backend` is ignored in headless MCP mode (`--mcp-stdio` / `--mcp-sse-port`): the headless path reads the stored backend directly. Set the backend first with a GUI launch or by editing the setting, then start in headless mode.
 - Unknown backend names fall back to FFmpeg with a warning.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -438,6 +438,8 @@ openterfaceQT [OPTIONS]
 
 | Argument                    | Description                                                |
 |-----------------------------|------------------------------------------------------------|
+| `--backend <NAME>`          | Select media backend (`ffmpeg`, `mediafoundation`, `qt`, `gstreamer`, `qtmultimedia`). Persisted to settings. |
+| `--list-backends`           | Print available media backends for the current platform and exit. |
 | `--mcp-stdio`               | Enable stdio transport (headless mode)                     |
 | `--mcp-pipe`                | Enable Named Pipe transport mode                           |
 | `--mcp-sse-port <PORT>`     | Enable SSE transport on TCP port (headless mode)           |
@@ -445,6 +447,13 @@ openterfaceQT [OPTIONS]
 | `--mcp-sse-bind-any`        | Bind SSE to 0.0.0.0 (all interfaces)                       |
 | `--mcp-start`               | Auto-start MCP server on launch (GUI mode)                 |
 | `--skip-env-check`          | Skip environment sanity check                              |
+
+**Media backend notes**:
+
+- `--backend` overrides the stored preference **and** persists the choice for subsequent launches. For a one-shot override, set via Settings UI and restore afterwards, or edit the `video/mediaBackend` key in the registry/config directly.
+- On Windows, available backends are `ffmpeg` (default, DirectShow), `mediafoundation` (native Windows Media Foundation), and `qt` (Qt Multimedia). On Linux, `ffmpeg` (V4L2) and `gstreamer`.
+- `--backend` is ignored in headless MCP mode (`--mcp-stdio` / `--mcp-sse-port`): the headless path reads the stored backend directly. Set the backend first with a GUI launch or by editing the setting, then start in headless mode.
+- Unknown backend names fall back to FFmpeg with a warning.
 
 ### 7.2 GUI Preferences Page
 

--- a/docs/preferences_pages_documentation.md
+++ b/docs/preferences_pages_documentation.md
@@ -180,11 +180,6 @@ Can also be set from the command line with `--backend <name>` (see [`MCP_SERVER.
 - Requires the Windows SDK redistributable (shipped with Windows)
 - Use when DirectShow has trouble claiming the device, or for lower CPU usage on supported hardware
 
-**Qt Multimedia** (Windows only, `qt`):
-- Qt's own multimedia wrapper
-- Useful for debugging or when other backends fail
-- Less flexible than FFmpeg / MF; does not support all device configurations
-
 **GStreamer** (Linux only):
 - Alternative multimedia framework
 - May provide better performance on some Linux configurations

--- a/docs/preferences_pages_documentation.md
+++ b/docs/preferences_pages_documentation.md
@@ -162,15 +162,30 @@ Example: `1920x1080 (30) - MJPEG`
 
 **Media Backend**: Selects which multimedia framework handles video Output and processing.
 
+Can also be set from the command line with `--backend <name>` (see [`MCP_SERVER.md`](MCP_SERVER.md) CLI reference). `--backend` persists the choice, so the same value is used by subsequent launches including headless MCP mode.
+
 #### Available Backends:
 
-**FFmpeg**:
+**FFmpeg** (Windows, Linux):
 - Most mature and widely compatible
 - Best performance on most systems
 - Excellent codec support
+- Uses DirectShow on Windows, V4L2 on Linux
 - Recommended default for most users
 
-**GStreamer**:
+**Media Foundation** (Windows only):
+- Native Windows capture framework (since Windows 7)
+- Lower CPU usage than DirectShow for some devices, because the driver can do format conversion in hardware
+- Supported pixel formats: RGB24 (preferred, MF does the conversion), NV12, YUY2
+- Requires the Windows SDK redistributable (shipped with Windows)
+- Use when DirectShow has trouble claiming the device, or for lower CPU usage on supported hardware
+
+**Qt Multimedia** (Windows only, `qt`):
+- Qt's own multimedia wrapper
+- Useful for debugging or when other backends fail
+- Less flexible than FFmpeg / MF; does not support all device configurations
+
+**GStreamer** (Linux only):
 - Alternative multimedia framework
 - May provide better performance on some Linux configurations
 - Useful if FFmpeg has compatibility issues

--- a/docs/tutorial/03-advanced-features.md
+++ b/docs/tutorial/03-advanced-features.md
@@ -33,10 +33,10 @@ The settings dialog (`SettingDialog`) uses a `QTreeWidget` on the left and `QSta
 Controls video capture behavior:
 - **Resolution** — Preferred capture resolution
 - **Frame rate** — Target FPS
-- **Media backend** — Choose between FFmpeg, GStreamer, or Qt Multimedia
+- **Media backend** — Choose between FFmpeg, GStreamer, or Media Foundation
   - **FFmpeg** — Direct FFmpeg-based capture (recommended for most users)
   - **GStreamer** — GStreamer pipeline-based (available on Linux)
-  - **Qt Multimedia** — Qt's native multimedia (Windows fallback)
+  - **Media Foundation** — Native Windows API (Windows only, lower CPU usage)
 - **Hardware acceleration** — VAAPI (Linux Intel), V4L2 (Linux) options when using FFmpeg
 - **Custom input resolution** — Override the auto-detected target resolution
 

--- a/docs/tutorial/04-architecture.md
+++ b/docs/tutorial/04-architecture.md
@@ -232,6 +232,22 @@ Linux-only backend. Runs GStreamer pipelines either in-process (`InProcessGstRun
 - `QtBackendHandler`: Windows-specific, wraps `QMediaRecorder` and `QMediaCaptureSession`.
 - `QtMultimediaBackendHandler`: Minimal fallback for platforms where FFmpeg/GStreamer are unavailable. No recording support.
 
+### MfBackendHandler (Media Foundation)
+
+**Files:** [`host/backend/mf/mfbackendhandler.h`](host/backend/mf/mfbackendhandler.h), [`host/backend/mf/mf_capture_manager.h`](host/backend/mf/mf_capture_manager.h)
+
+Windows-only backend built on the native Media Foundation API (`IMFSourceReader`). Preferred when DirectShow has trouble claiming the device, or when a lower-CPU path is desired — MF can delegate format conversion to the driver.
+
+| Component | File | Responsibility |
+|-----------|------|---------------|
+| `MfBackendHandler` | [`host/backend/mf/mfbackendhandler.h`](host/backend/mf/mfbackendhandler.h) | Backend lifecycle, FPS timer, frame delivery to `VideoPane` |
+| `MfCaptureManager` | [`host/backend/mf/mf_capture_manager.h`](host/backend/mf/mf_capture_manager.h) | Activates the device from the symbolic link, owns the source reader and capture thread |
+| `MfCaptureThread` | same | QThread that calls `IMFSourceReader::ReadSample` in a loop |
+| `MfFrameProcessor` | [`host/backend/mf/mf_frame_processor.h`](host/backend/mf/mf_frame_processor.h) | Converts the device's native pixel format (NV12/YUY2/RGB24) to `QImage::Format_BGR888` using FFmpeg's `sws_scale` |
+| `MfDeviceEnumerator` | [`host/backend/mf/mf_device_enumerator.h`](host/backend/mf/mf_device_enumerator.h) | Enumerates video capture devices via `MFEnumDeviceSources` (used only for auto-select fallback) |
+
+**Pixel format note:** MF's `MFVideoFormat_RGB24` uses the Windows bitmap byte order (B, G, R), which matches `QImage::Format_BGR888` directly. The frame processor therefore has a fast path that skips `sws_scale` entirely for RGB24 input, and uses `AV_PIX_FMT_BGR24` as the sws_scale destination for NV12/YUY2 inputs to keep the output layout consistent.
+
 ### Hardware Acceleration
 
 **File:** [`host/backend/ffmpeg/ffmpeg_hardware_accelerator.h`](host/backend/ffmpeg/ffmpeg_hardware_accelerator.h)

--- a/docs/tutorial/04-architecture.md
+++ b/docs/tutorial/04-architecture.md
@@ -28,7 +28,7 @@ The codebase follows a modular directory layout where each directory owns a dist
 | Directory | Purpose | Key Classes |
 |-----------|---------|-------------|
 | [`ui/`](ui/) | GUI widgets, dialogs, preferences, toolbars, coordinators | `MainWindow`, `VideoPane`, `DeviceCoordinator`, `MenuCoordinator`, `WindowLayoutCoordinator`, `GlobalSetting` |
-| [`host/`](host/) | Video/audio capture backends, camera management, USB control | `CameraManager`, `MultimediaBackendHandler`, `FFmpegBackendHandler`, `GStreamerBackendHandler`, `QtBackendHandler`, `QtMultimediaBackendHandler`, `AudioManager` |
+| [`host/`](host/) | Video/audio capture backends, camera management, USB control | `CameraManager`, `MultimediaBackendHandler`, `FFmpegBackendHandler`, `GStreamerBackendHandler`, `MfBackendHandler`, `AudioManager` |
 | [`serial/`](serial/) | Serial port communication, protocol parsing, chip strategies | `SerialPortManager`, `SerialProtocol`, `IChipStrategy`, `CH9329Strategy`, `CH32V208Strategy`, `ChipStrategyFactory`, `ConnectionWatchdog`, `SerialCommandCoordinator` |
 | [`video/`](video/) | HID transport for video capture chips, firmware operations | `VideoHid`, `IHIDTransport`, `LinuxHIDTransport`, `WindowsHIDTransport`, `VideoChip`, `Ms2109Chip`, `Ms2109sChip`, `Ms2130sChip`, `FirmwareOperationManager` |
 | [`device/`](device/) | Platform-agnostic device enumeration, hotplug monitoring | `DeviceManager`, `DeviceInfo`, `HotplugMonitor`, `AbstractPlatformDeviceManager` |
@@ -177,9 +177,8 @@ The video capture system uses a **pluggable backend** pattern with a factory sel
 CameraManager
   └── MultimediaBackendHandler (abstract base)
         ├── FFmpegBackendHandler     (default, most feature-complete)
-        ├── GStreamerBackendHandler  (Linux only)
-        ├── QtBackendHandler         (Windows-specific)
-        └── QtMultimediaBackendHandler (minimal fallback)
+        ├── MfBackendHandler         (Windows Media Foundation)
+        └── GStreamerBackendHandler  (Linux only)
 ```
 
 ### Base Class: `MultimediaBackendHandler`
@@ -224,13 +223,6 @@ Supports direct V4L2 capture, hardware-accelerated decoding (VAAPI, V4L2-M2M), T
 **File:** [`host/backend/gstreamerbackendhandler.h`](host/backend/gstreamerbackendhandler.h)
 
 Linux-only backend. Runs GStreamer pipelines either in-process (`InProcessGstRunner`) or externally via `gst-launch-1.0` subprocess (`ExternalGstRunner`). Supports multiple recording strategies (valve-based tee, frame-based appsink, direct filesink).
-
-### QtBackendHandler / QtMultimediaBackendHandler
-
-**Files:** [`host/backend/qtbackendhandler.h`](host/backend/qtbackendhandler.h), [`host/backend/qtmultimediabackendhandler.h`](host/backend/qtmultimediabackendhandler.h)
-
-- `QtBackendHandler`: Windows-specific, wraps `QMediaRecorder` and `QMediaCaptureSession`.
-- `QtMultimediaBackendHandler`: Minimal fallback for platforms where FFmpeg/GStreamer are unavailable. No recording support.
 
 ### MfBackendHandler (Media Foundation)
 

--- a/docs/tutorial/06-platform-guides.md
+++ b/docs/tutorial/06-platform-guides.md
@@ -191,17 +191,14 @@ The application itself does **not** require admin elevation to run — device ac
 
 ### Media Backend Selection (Windows)
 
-Windows builds ship three multimedia backends. The active backend can be changed at runtime via **Preferences → Video → Media Backend** or at launch via the CLI flag `--backend <name>` (the choice is persisted to `HKCU\Software\TechxArtisan\Openterface\video\mediaBackend`).
+Windows builds ship two multimedia backends. The active backend can be changed at runtime via **Preferences → Video → Media Backend** or at launch via the CLI flag `--backend <name>` (the choice is persisted to `HKCU\Software\TechxArtisan\Openterface\video\mediaBackend`).
 
 | Backend | ID | Notes |
 |---|---|---|
 | FFmpeg (DirectShow) | `ffmpeg` | Default. Most mature path. Uses the `FFmpegBackendHandler` composition. |
 | Media Foundation | `mediafoundation` | Native Windows API (`IMFSourceReader`). Lower CPU on some devices, because the driver can do format conversion in hardware. |
-| Qt Multimedia | `qt` | Wraps `QMediaCaptureSession`. Useful as a fallback. Known to fail on the MS2130S composite device because the Windows device enumerator cannot resolve the camera interface for that topology — see note below. |
 
 **Choosing Media Foundation:** use it when FFmpeg/DirectShow cannot claim the device, or when you want lower CPU usage on hardware that supports in-driver conversion. The MF path prefers `MFVideoFormat_RGB24` so the driver does the conversion; the frame processor has a fast path that skips `sws_scale` entirely for RGB24 and only runs it for NV12/YUY2 fallbacks.
-
-**Known issue — Qt backend on composite USB video devices:** the Windows device enumerator (`WinDeviceEnumerator::getAllInterfacePathsForDevice`) walks composite device children looking for a camera interface by `KSCATEGORY_CAPTURE`. On the MS2130S (VID:PID `345F:2132`) the camera interface is registered on the MI_00 child but the enumerator fails to match it, so the Qt backend has no device to open. FFmpeg (which has its own DirectShow enumeration) and MF (which uses the device symbolic link directly) are unaffected. Fixing this requires teaching the enumerator to walk the composite children's interface GUIDs — patches welcome.
 
 ---
 

--- a/docs/tutorial/06-platform-guides.md
+++ b/docs/tutorial/06-platform-guides.md
@@ -189,6 +189,20 @@ The installer requires administrator privileges to:
 
 The application itself does **not** require admin elevation to run — device access is granted through the standard Windows HID and COM port APIs.
 
+### Media Backend Selection (Windows)
+
+Windows builds ship three multimedia backends. The active backend can be changed at runtime via **Preferences → Video → Media Backend** or at launch via the CLI flag `--backend <name>` (the choice is persisted to `HKCU\Software\TechxArtisan\Openterface\video\mediaBackend`).
+
+| Backend | ID | Notes |
+|---|---|---|
+| FFmpeg (DirectShow) | `ffmpeg` | Default. Most mature path. Uses the `FFmpegBackendHandler` composition. |
+| Media Foundation | `mediafoundation` | Native Windows API (`IMFSourceReader`). Lower CPU on some devices, because the driver can do format conversion in hardware. |
+| Qt Multimedia | `qt` | Wraps `QMediaCaptureSession`. Useful as a fallback. Known to fail on the MS2130S composite device because the Windows device enumerator cannot resolve the camera interface for that topology — see note below. |
+
+**Choosing Media Foundation:** use it when FFmpeg/DirectShow cannot claim the device, or when you want lower CPU usage on hardware that supports in-driver conversion. The MF path prefers `MFVideoFormat_RGB24` so the driver does the conversion; the frame processor has a fast path that skips `sws_scale` entirely for RGB24 and only runs it for NV12/YUY2 fallbacks.
+
+**Known issue — Qt backend on composite USB video devices:** the Windows device enumerator (`WinDeviceEnumerator::getAllInterfacePathsForDevice`) walks composite device children looking for a camera interface by `KSCATEGORY_CAPTURE`. On the MS2130S (VID:PID `345F:2132`) the camera interface is registered on the MI_00 child but the enumerator fails to match it, so the Qt backend has no device to open. FFmpeg (which has its own DirectShow enumeration) and MF (which uses the device symbolic link directly) are unaffected. Fixing this requires teaching the enumerator to walk the composite children's interface GUIDs — patches welcome.
+
 ---
 
 ## Raspberry Pi

--- a/docs/tutorial/07-troubleshooting.md
+++ b/docs/tutorial/07-troubleshooting.md
@@ -148,8 +148,7 @@ The video backend affects compatibility:
 |---------|----------|----------|
 | FFmpeg | All | Most reliable, hardware acceleration |
 | GStreamer | Linux | Pipeline flexibility |
-| Qt Multimedia | Windows | Simple setups |
-| Qt | Windows | Native QMediaRecorder |
+| Media Foundation | Windows | Lower CPU usage, native API |
 
 **Switch backend:** **Preferences → Video → Media Backend**. Restart the application after changing.
 
@@ -351,7 +350,7 @@ Switching the target control mode repeatedly can cause the application to crash.
 
 ### Qt Multimedia During Shutdown
 
-The application uses `g_applicationShuttingDown` (atomic flag) to prevent Qt Multimedia operations during shutdown. If you see crashes during close, ensure:
+The application uses `g_applicationShuttingDown` (atomic flag) to prevent Qt Multimedia operations (recording, capture session) during shutdown. If you see crashes during close, ensure:
 - You are running a recent version
 - The shutdown flag is properly checked before Qt Multimedia calls
 

--- a/host/backend/ffmpeg_compat_shim.c
+++ b/host/backend/ffmpeg_compat_shim.c
@@ -1,47 +1,31 @@
 /*
  * Compatibility shim for FFmpeg static libs built with newer MinGW-w64.
- * Bridges 64-bit time functions and stack protector symbols to older MinGW 11.2.0.
+ * Bridges 64-bit time functions to older MinGW 11.2.0 (Qt 6.5/6.6 default).
  *
- * All symbols are declared __attribute__((weak)) so that if the runtime
- * already provides them (e.g. MSYS2 mingw64 libwinpthread), the linker
- * will prefer the strong definitions from the system library.
+ * NOTE: do NOT use __attribute__((weak)) here — on MinGW-w64 < 12 the
+ * attribute produces malformed symbol names like `.weak.clock_gettime64.`
+ * which the linker cannot match, leaving FFmpeg's undefined refs unresolved.
+ * The version guard below is the correct safety net: on MinGW-w64 >= 12 the
+ * system headers already provide these symbols, so the shim is skipped.
  */
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* 64-bit time function wrappers - map to 32-bit versions (fine for Windows) */
 #include <time.h>
 
-#ifdef __MINGW32__
-#define SHIM_ATTR __attribute__((weak))
-#else
-#define SHIM_ATTR
-#endif
-
-/*
- * Newer MinGW-w64 (>= 12.x) already declares clock_gettime64 / nanosleep64 /
- * pthread_cond_timedwait64 in <pthread_time.h> and <pthread.h> with
- * 'struct _timespec64*' parameters. Defining them again with 'struct timespec*'
- * causes a conflicting-types error.
- * Skip our shim when the system provides these functions.
- */
 #if !defined(__MINGW64_VERSION_MAJOR) || (__MINGW64_VERSION_MAJOR < 12)
 
-SHIM_ATTR int clock_gettime64(int clock_id, struct timespec *ts) {
+int clock_gettime64(int clock_id, struct timespec *ts) {
     return clock_gettime(clock_id, ts);
 }
 
-SHIM_ATTR int nanosleep64(const struct timespec *req, struct timespec *rem) {
+int nanosleep64(const struct timespec *req, struct timespec *rem) {
     return nanosleep(req, rem);
 }
 
-/* pthread cond timedwait - delegate to regular version */
-SHIM_ATTR int pthread_cond_timedwait64(void *cond, void *mutex, const struct timespec *abstime) {
-    /* Forward to the regular pthread_cond_timedwait from libwinpthread */
-    typedef int (*pthread_cond_timedwait_fn)(void*, void*, const struct timespec*);
-    /* libwinpthread exports pthread_cond_timedwait - just call it */
-    extern int pthread_cond_timedwait(void *cond, void *mutex, const struct timespec *abstime);
+extern int pthread_cond_timedwait(void *cond, void *mutex, const struct timespec *abstime);
+int pthread_cond_timedwait64(void *cond, void *mutex, const struct timespec *abstime) {
     return pthread_cond_timedwait(cond, mutex, abstime);
 }
 

--- a/host/backend/mf/mf_capture_manager.cpp
+++ b/host/backend/mf/mf_capture_manager.cpp
@@ -284,12 +284,24 @@ bool MfCaptureManager::initialize(const QString& deviceSymbolicLink, const QSize
         return false;
     }
 
-    // Try NV12 first (most widely supported), then RGB24
-    GUID subtypes[] = { MFVideoFormat_NV12, MFVideoFormat_RGB24, MFVideoFormat_YUY2 };
+    // Try RGB24 first (MF does the pixel conversion in hardware, no sws_scale
+    // needed). Fall back to NV12, then YUY2 if the device doesn't support RGB24.
+    // NOTE: order matters — the frame processor is initialized with whatever
+    // format we actually got from MF, so we must track the chosen format.
+    struct FormatEntry {
+        GUID subtype;
+        const char* name;
+    };
+    FormatEntry subtypes[] = {
+        { MFVideoFormat_RGB24, "RGB24" },
+        { MFVideoFormat_NV12,  "NV12"  },
+        { MFVideoFormat_YUY2,  "YUY2"  },
+    };
     bool typeSet = false;
+    const char* chosenFormatName = nullptr;
 
-    for (const auto& subtype : subtypes) {
-        hr = mediaType->SetGUID(MF_MT_SUBTYPE, subtype);
+    for (const auto& entry : subtypes) {
+        hr = mediaType->SetGUID(MF_MT_SUBTYPE, entry.subtype);
         if (FAILED(hr)) continue;
 
         hr = MFSetAttributeSize(mediaType, MF_MT_FRAME_SIZE, resolution.width(), resolution.height());
@@ -304,7 +316,8 @@ bool MfCaptureManager::initialize(const QString& deviceSymbolicLink, const QSize
         hr = sourceReader_->SetCurrentMediaType(0, nullptr, mediaType);
         if (SUCCEEDED(hr)) {
             typeSet = true;
-            qCInfo(log_multimedia_backend) << "Media type set successfully";
+            chosenFormatName = entry.name;
+            qCInfo(log_multimedia_backend) << "Media type set successfully:" << entry.name;
             break;
         }
     }
@@ -317,10 +330,14 @@ bool MfCaptureManager::initialize(const QString& deviceSymbolicLink, const QSize
         return false;
     }
 
-    // Initialize frame processor with NV12 (our preferred format)
+    // Initialize frame processor with the ACTUAL format MF is producing.
+    // This is critical — passing the wrong format to sws_scale causes
+    // color corruption / invalid images.
     frameProcessor_ = new MfFrameProcessor();
-    if (!frameProcessor_->initialize(resolution.width(), resolution.height(), "NV12")) {
-        qCCritical(log_multimedia_backend) << "Failed to initialize frame processor";
+    if (!frameProcessor_->initialize(resolution.width(), resolution.height(),
+                                     QString::fromUtf8(chosenFormatName))) {
+        qCCritical(log_multimedia_backend) << "Failed to initialize frame processor for"
+                                           << chosenFormatName;
         cleanupMediaFoundation();
         return false;
     }

--- a/host/backend/mf/mf_frame_processor.cpp
+++ b/host/backend/mf/mf_frame_processor.cpp
@@ -47,9 +47,12 @@ bool MfFrameProcessor::initialize(int width, int height, const QString& inputFor
     }
 
 #ifdef HAVE_FFMPEG
+    // Output BGR24 — matches MFVideoFormat_RGB24's byte layout (B, G, R) and
+    // QImage::Format_BGR888. Keeping the output in BGR throughout avoids an
+    // unnecessary byte-swap pass on the fast path.
     swsContext_ = sws_getContext(
         width_, height_, srcFormat,
-        width_, height_, AV_PIX_FMT_RGB24,
+        width_, height_, AV_PIX_FMT_BGR24,
         SWS_BILINEAR, nullptr, nullptr, nullptr
     );
 
@@ -59,7 +62,7 @@ bool MfFrameProcessor::initialize(int width, int height, const QString& inputFor
         return false;
     }
 
-    rgbBufferSize_ = width_ * height_ * 3; // RGB24
+    rgbBufferSize_ = width_ * height_ * 3; // BGR24
     rgbBuffer_ = new uchar[rgbBufferSize_];
 #else
     qCCritical(log_multimedia_backend) << "FFmpeg not available for frame conversion";
@@ -74,38 +77,77 @@ bool MfFrameProcessor::initialize(int width, int height, const QString& inputFor
 
 QImage MfFrameProcessor::processFrame(const uchar* data, int dataSize)
 {
-    if (!data || !swsContext_ || dataSize <= 0) {
+    if (!data || dataSize <= 0) {
         return QImage();
     }
 
 #ifdef HAVE_FFMPEG
-    const uint8_t* srcSlice[1] = { data };
-    int srcStride[1] = { 0 };
+    // Fast path: MF's MFVideoFormat_RGB24 stores bytes in BGR order (B, G, R)
+    // per the Windows bitmap convention. QImage::Format_BGR888 matches that
+    // layout exactly, so no byte reordering is needed — just copy.
+    // (If we used Format_RGB888 here, red and blue would be swapped: red
+    // objects would appear purple/cyan.)
+    if (inputFormat_ == "RGB24") {
+        const int expected = width_ * height_ * 3;
+        if (dataSize < expected) {
+            qCWarning(log_multimedia_backend) << "RGB24 buffer too small:"
+                                              << dataSize << "<" << expected;
+            return QImage();
+        }
+        // Construct QImage over the source buffer, then .copy() into our
+        // owned memory so it outlives the MF buffer lock.
+        return QImage(data, width_, height_, width_ * 3, QImage::Format_BGR888).copy();
+    }
 
-    // Calculate source stride based on format
-    if (inputFormat_ == "NV12") {
-        srcStride[0] = width_; // NV12 stride is width for Y plane
-    } else if (inputFormat_ == "YUY2" || inputFormat_ == "YUYV") {
-        srcStride[0] = width_ * 2; // YUY2 is 2 bytes per pixel
-    } else if (inputFormat_ == "RGB24") {
-        srcStride[0] = width_ * 3;
-    } else if (inputFormat_ == "RGB32") {
-        srcStride[0] = width_ * 4;
-    } else {
-        srcStride[0] = width_; // Default
+    if (!swsContext_) {
+        qCWarning(log_multimedia_backend) << "sws context null for format" << inputFormat_;
+        return QImage();
     }
 
     uint8_t* dstSlice[1] = { rgbBuffer_ };
     int dstStride[1] = { width_ * 3 };
 
-    sws_scale(
-        swsContext_,
-        srcSlice, srcStride,
-        0, height_,
-        dstSlice, dstStride
-    );
+    if (inputFormat_ == "NV12") {
+        // NV12 is a 2-plane format:
+        //   Plane 0: Y samples,      stride = width, size = width * height
+        //   Plane 1: interleaved UV, stride = width, size = width * height/2
+        // Total size = width * height * 3/2.
+        // The MF sample buffer is contiguous, so the UV plane starts at
+        // data + width*height.
+        const int ySize = width_ * height_;
+        if (dataSize < ySize + ySize / 2) {
+            qCWarning(log_multimedia_backend) << "NV12 buffer too small:"
+                                              << dataSize << "<" << (ySize + ySize / 2);
+            return QImage();
+        }
+        const uint8_t* srcSlice[2] = { data, data + ySize };
+        int srcStride[2] = { width_, width_ };
 
-    return QImage(rgbBuffer_, width_, height_, dstStride[0], QImage::Format_RGB888).copy();
+        sws_scale(swsContext_,
+                  srcSlice, srcStride,
+                  0, height_,
+                  dstSlice, dstStride);
+    } else {
+        // Single-plane formats (YUY2, RGB32, etc.)
+        const uint8_t* srcSlice[1] = { data };
+        int srcStride[1] = { 0 };
+
+        if (inputFormat_ == "YUY2" || inputFormat_ == "YUYV") {
+            srcStride[0] = width_ * 2;
+        } else if (inputFormat_ == "RGB32") {
+            srcStride[0] = width_ * 4;
+        } else {
+            srcStride[0] = width_;
+        }
+
+        sws_scale(swsContext_,
+                  srcSlice, srcStride,
+                  0, height_,
+                  dstSlice, dstStride);
+    }
+
+    // sws_scale output is BGR24 (matches MFVideoFormat_RGB24 convention)
+    return QImage(rgbBuffer_, width_, height_, dstStride[0], QImage::Format_BGR888).copy();
 #else
     Q_UNUSED(dataSize);
     return QImage();

--- a/host/backend/mf/mfbackendhandler.cpp
+++ b/host/backend/mf/mfbackendhandler.cpp
@@ -129,12 +129,29 @@ void MfBackendHandler::startCamera()
         return;
     }
 
+    // Start FPS timer — fires every 1s, emits fpsChanged with the frame count
+    // from the previous interval. The capture thread increments frameCounter_
+    // in onFrameReady; this timer (main thread) reads and resets it.
+    if (!fpsTimer_) {
+        fpsTimer_ = new QTimer(this);
+        fpsTimer_->setInterval(1000);
+        connect(fpsTimer_, &QTimer::timeout, this, &MfBackendHandler::onFpsTimerTick);
+    }
+    frameCounter_.store(0, std::memory_order_relaxed);
+    fpsTimer_->start();
+
     qCInfo(log_multimedia_backend) << "Media Foundation camera started successfully";
 }
 
 void MfBackendHandler::stopCamera()
 {
     qCInfo(log_multimedia_backend) << "Media Foundation backend: stopping camera";
+
+    if (fpsTimer_) {
+        fpsTimer_->stop();
+    }
+    frameCounter_.store(0, std::memory_order_relaxed);
+    emit fpsChanged(0.0);
 
     if (captureManager_) {
         captureManager_->stopCapture();
@@ -144,6 +161,11 @@ void MfBackendHandler::stopCamera()
 void MfBackendHandler::cleanupCamera()
 {
     qCInfo(log_multimedia_backend) << "Media Foundation backend: cleaning up camera";
+
+    if (fpsTimer_) {
+        fpsTimer_->stop();
+    }
+    frameCounter_.store(0, std::memory_order_relaxed);
 
     if (captureManager_) {
         captureManager_->stopCapture();
@@ -210,7 +232,17 @@ QStringList MfBackendHandler::getAvailableHardwareAccelerations() const
 
 void MfBackendHandler::onFrameReady(const QImage& frame)
 {
+    frameCounter_.fetch_add(1, std::memory_order_relaxed);
     emit frameReadyImage(frame);
+}
+
+void MfBackendHandler::onFpsTimerTick()
+{
+    // exchange() atomically reads and resets the counter in one operation,
+    // so frames that arrive between the read and the next tick aren't lost.
+    const qint64 frames = frameCounter_.exchange(0, std::memory_order_relaxed);
+    // Timer interval is 1000 ms, so frames == fps directly.
+    emit fpsChanged(static_cast<double>(frames));
 }
 
 void MfBackendHandler::onCaptureError(const QString& error)

--- a/host/backend/mf/mfbackendhandler.h
+++ b/host/backend/mf/mfbackendhandler.h
@@ -7,6 +7,8 @@
 #include <QCameraFormat>
 #include <QSize>
 #include <QMetaObject>
+#include <QTimer>
+#include <atomic>
 #include <memory>
 
 // Forward declarations
@@ -49,6 +51,7 @@ private slots:
     void onFrameReady(const QImage& frame);
     void onCaptureError(const QString& error);
     void onDeviceDisconnected();
+    void onFpsTimerTick();
 
 private:
     bool setupCaptureSession();
@@ -64,6 +67,11 @@ private:
     QSize resolution_;
     int framerate_;
     bool isRecording_;
+
+    // FPS tracking. onFrameReady runs on the capture thread, so the counter
+    // must be atomic. The timer fires on the main thread to read and reset it.
+    QTimer* fpsTimer_ = nullptr;
+    std::atomic<qint64> frameCounter_{0};
 };
 
 #endif // MFBACKENDHANDLER_H

--- a/host/cameramanager.cpp
+++ b/host/cameramanager.cpp
@@ -368,10 +368,10 @@ void CameraManager::startCamera()
         }
         
 #ifdef Q_OS_WIN
-        // On Windows builds, only the FFmpeg backend is supported.
-        // For Linux build, both FFmepg and GStreamer backends are supported.
-        if (!isFFmpegBackend()) {
-            qCWarning(log_backend) << "Only FFmpeg backend is supported on Windows";
+        // On Windows builds, FFmpeg and Media Foundation backends are supported.
+        // For Linux build, both FFmpeg and GStreamer backends are supported.
+        if (!isFFmpegBackend() && !isMediaFoundationBackend()) {
+            qCWarning(log_backend) << "Only FFmpeg and Media Foundation backends are supported on Windows";
             return;
         }
 #endif
@@ -986,6 +986,20 @@ bool CameraManager::switchToCameraDevice(const QCameraDevice &cameraDevice, cons
             qCDebug(log_ui_camera) << "Set device path in GStreamer backend:" << devicePath;
         }
         #endif
+
+#ifdef Q_OS_WIN
+        if (MfBackendHandler* mfHandler = qobject_cast<MfBackendHandler*>(m_backendHandler.get())) {
+            // For MF, use the cameraDevicePath from DeviceInfo (symbolic link)
+            // rather than the Qt QCamera-based convertCameraDeviceToPath.
+            DeviceInfo mfDevInfo = DeviceManager::getInstance().getCurrentSelectedDevice();
+            if (!mfDevInfo.cameraDevicePath.isEmpty()) {
+                mfHandler->setDevicePath(mfDevInfo.cameraDevicePath);
+                qCDebug(log_ui_camera) << "Set camera symbolic link in MF backend:" << mfDevInfo.cameraDevicePath;
+            } else {
+                qCWarning(log_ui_camera) << "No camera symbolic link available for MF backend";
+            }
+        }
+#endif
 
         // Start camera with new device
         startCamera();
@@ -1670,6 +1684,21 @@ bool CameraManager::initializeCameraWithVideoOutput(VideoPane* videoPane, bool s
 
             mfHandler->setResolution(resolution);
             mfHandler->setFramerate(framerate);
+
+            // Pass the camera device symbolic link to the MF handler.
+            // The Windows device enumerator resolves this to the \\?\usb#... form
+            // that MF's MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK expects.
+            // Without this, devicePath_ stays empty and startCamera() blindly
+            // auto-selects the first device from MFEnumDeviceSources (often wrong).
+            DeviceInfo mfSelectedDevice = DeviceManager::getInstance().getCurrentSelectedDevice();
+            if (!mfSelectedDevice.cameraDevicePath.isEmpty()) {
+                mfHandler->setDevicePath(mfSelectedDevice.cameraDevicePath);
+                qCDebug(log_ui_camera) << "MF: using camera symbolic link:"
+                                       << mfSelectedDevice.cameraDevicePath;
+            } else {
+                qCWarning(log_ui_camera) << "MF: no camera device path in selected device,"
+                                            " falling back to auto-select first MF device";
+            }
 
             if (startCapture) {
                 mfHandler->startCamera();

--- a/openterfaceQT.pro
+++ b/openterfaceQT.pro
@@ -44,11 +44,12 @@ SOURCES += main.cpp \
     host/backend/ffmpeg/ffmpeg_hardware_accelerator.cpp \
     host/backend/ffmpeg/ffmpeg_device_manager.cpp \
     host/backend/ffmpeg/ffmpeg_frame_processor.cpp \
-    host/backend/ffmpeg/ffmpeg_amd_detector.cpp \
     host/backend/ffmpeg/ffmpeg_recorder.cpp \
     host/backend/ffmpeg/ffmpeg_device_validator.cpp \
     host/backend/ffmpeg/ffmpeg_hotplug_handler.cpp \
     host/backend/ffmpeg/ffmpeg_capture_manager.cpp \
+    host/backend/ffmpeg/ffmpeg_amd_detector.cpp \
+    host/backend/ffmpeg_compat_shim.c \
     regex/RegularExpression.cpp \
     scripts/KeyboardMouse.cpp \
     scripts/Lexer.cpp \
@@ -234,6 +235,7 @@ HEADERS  += \
     host/backend/ffmpeg/ffmpeg_device_validator.h \
     host/backend/ffmpeg/ffmpeg_hotplug_handler.h \
     host/backend/ffmpeg/ffmpeg_capture_manager.h \
+    host/backend/ffmpeg/ffmpeg_amd_detector.h \
     host/backend/ffmpeg/icapture_frame_reader.h \
     host/backend/ffmpeg/ffmpegutils.h \
     regex/RegularExpression.h \
@@ -400,53 +402,132 @@ win32 {
         device/platform/windows/discoverers/Generation3Discoverer.cpp \
         device/platform/windows/discoverers/DeviceDiscoveryManager.cpp \
         video/transport/WindowsHIDTransport.cpp \
-        SysKeyBlocker/SystemKeyBlocker_win.cpp
+        SysKeyBlocker/SystemKeyBlocker_win.cpp \
+        host/backend/mf/mfbackendhandler.cpp \
+        host/backend/mf/mf_capture_manager.cpp \
+        host/backend/mf/mf_device_enumerator.cpp \
+        host/backend/mf/mf_frame_processor.cpp
     HEADERS += device/platform/WindowsDeviceManager.h \
         video/transport/WindowsHIDTransport.h \
         device/platform/windows/discoverers/IDeviceDiscoverer.h \
         device/platform/windows/discoverers/BaseDeviceDiscoverer.h \
         device/platform/windows/discoverers/BotherDeviceDiscoverer.h \
         device/platform/windows/discoverers/Generation3Discoverer.h \
-        device/platform/windows/discoverers/DeviceDiscoveryManager.h
+        device/platform/windows/discoverers/DeviceDiscoveryManager.h \
+        host/backend/mf/mfbackendhandler.h \
+        host/backend/mf/mf_capture_manager.h \
+        host/backend/mf/mf_device_enumerator.h \
+        host/backend/mf/mf_frame_processor.h
     
     INCLUDEPATH += $$PWD/lib
-    INCLUDEPATH += C:\ffmpeg-static\include
+    # FFmpeg prefix. Resolution order:
+    #   1. qmake arg:       qmake "FFMPEG_PREFIX=D:/ffmpeg"
+    #   2. env var:         set FFMPEG_PREFIX=D:\ffmpeg
+    #   3. default:         C:/ffmpeg-static (or C:/ffmpeg-shared with CONFIG+=shared_ffmpeg)
+    # Usage:  qmake "CONFIG+=shared_ffmpeg" "FFMPEG_PREFIX=C:/ffmpeg-shared"
+    # Mirrors cmake -DUSE_SHARED_FFMPEG=ON -DFFMPEG_PREFIX=...
+    contains(CONFIG, shared_ffmpeg): FF_MODE = shared
+    else: FF_MODE = static
+    isEmpty(FFMPEG_PREFIX) {
+        FFMPEG_PREFIX = $$(FFMPEG_PREFIX)
+    }
+    isEmpty(FFMPEG_PREFIX) {
+        equals(FF_MODE, shared): FFMPEG_PREFIX = C:/ffmpeg-shared
+        else: FFMPEG_PREFIX = C:/ffmpeg-static
+    }
+    message("Using FFmpeg prefix: $$FFMPEG_PREFIX (mode: $$FF_MODE)")
+    INCLUDEPATH += $$FFMPEG_PREFIX/include
+
     LIBS += -L$$PWD/lib -llibusb-1.0 -loleaut32 -lwinpthread
-    # Prefer ffmpeg libs from C:/ffmpeg-static, also search msys2 mingw64; only add -lmfx if libmfx exists
-    FF_LIB_DIR = C:/ffmpeg-static/lib
-    MSYS_LIB_DIR = C:/msys64/mingw64/lib
-    MFX_FF = $$FF_LIB_DIR/libmfx.a
+
+    # MSYS2/MinGW sysroot for FFmpeg transitive deps (zlib, bz2, lzma, mfx, winpthread, iconv).
+    # Resolution order: 1) qmake arg MSYS_PREFIX  2) env MSYS_PREFIX  3) C:/msys64
+    isEmpty(MSYS_PREFIX) {
+        MSYS_PREFIX = $$(MSYS_PREFIX)
+    }
+    isEmpty(MSYS_PREFIX) {
+        MSYS_PREFIX = C:/msys64
+    }
+    MSYS_LIB_DIR = $$MSYS_PREFIX/mingw64/lib
     MFX_MSYS = $$MSYS_LIB_DIR/libmfx.a
-    # Ensure the ffmpeg lib dir is searched first so -lav* resolves
-    LIBS += -L$$FF_LIB_DIR -L$$MSYS_LIB_DIR
-    exists($$MFX_FF) {
-        message("Using libmfx from $$MFX_FF")
-        LIBS += -Wl,--start-group -lavcodec -lavformat -lavutil -lavdevice -lswscale -lswresample -lmfx -lz -Wl,--end-group
-    } else {
-        exists($$MFX_MSYS) {
+    message("Using MSYS2 lib dir: $$MSYS_LIB_DIR")
+    LIBS += -L$$MSYS_LIB_DIR
+
+    equals(FF_MODE, shared) {
+        # ---- Shared FFmpeg (import libs from $$FFMPEG_PREFIX/lib) ----
+        # Mirrors cmake/FFmpeg.cmake: link .dll.a import libs + Windows system deps.
+        SHARED_FF_LIB_DIR = $$FFMPEG_PREFIX/lib
+        LIBS += -L$$SHARED_FF_LIB_DIR
+        LIBS += -lavdevice -lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil
+
+        # Windows system libs required by shared FFmpeg (same set as CMake HWACCEL_LIBRARIES)
+        LIBS += -lws2_32 -lsecur32 -lbcrypt -lole32 -lstrmiids
+        LIBS += -lvfw32 -lgdi32 -lshlwapi -lwinmm -luuid -loleaut32
+
+        # Intel QSV (libmfx) - prefer ffmpeg-static copy, fallback to MSYS2
+        exists($$FFMPEG_PREFIX/lib/libmfx.a) {
+            message("Using libmfx from $$FFMPEG_PREFIX/lib/libmfx.a")
+            LIBS += $$FFMPEG_PREFIX/lib/libmfx.a
+        } else:exists($$MFX_MSYS) {
             message("Using libmfx from $$MFX_MSYS")
-            LIBS += -Wl,--start-group -lavcodec -lavformat -lavutil -lavdevice -lswscale -lswresample -lmfx -lz -Wl,--end-group
+            LIBS += $$MFX_MSYS
         } else {
-            message("libmfx not found; building without -lmfx. Install Intel oneVPL or place libmfx in C:/ffmpeg-static/lib or C:/msys64/mingw64/lib to enable.")
-            LIBS += -Wl,--start-group -lavcodec -lavformat -lavutil -lavdevice -lswscale -lswresample -lz -Wl,--end-group
+            message("libmfx not found - QSV support disabled")
         }
+
+        # Shared FFmpeg transitive deps (zlib, bz2, lzma, winpthread)
+        LIBS += -lz -lbz2 -llzma -lwinpthread
+        DEFINES += HAVE_FFMPEG
+
+        # libjpeg-turbo (optional, matches CMake HAVE_LIBJPEG_TURBO detection)
+        exists($$FFMPEG_PREFIX/lib/libturbojpeg.a) {
+            LIBS += $$FFMPEG_PREFIX/lib/libturbojpeg.a
+            DEFINES += HAVE_LIBJPEG_TURBO
+            message("Using libturbojpeg from $$FFMPEG_PREFIX/lib/libturbojpeg.a")
+        } else {
+            exists($$MSYS_LIB_DIR/libturbojpeg.a) {
+                LIBS += $$MSYS_LIB_DIR/libturbojpeg.a
+                DEFINES += HAVE_LIBJPEG_TURBO
+            }
+        }
+    } else {
+        # ---- Static FFmpeg (whole-archive from $$FFMPEG_PREFIX/lib) ----
+        # Mirrors cmake link_ffmpeg_libraries() static branch.
+        # IMPORTANT: do NOT use --start-group/--end-group — the linker loop
+        # pulls objects repeatedly and corrupts init tables (0xC0000409).
+        # IMPORTANT: FFmpeg .a files MUST come BEFORE the system libs that
+        # satisfy their undefined refs (left-to-right resolution).
+        FF_LIB_DIR = $$FFMPEG_PREFIX/lib
+        LIBS += -L$$FF_LIB_DIR
+        LIBS += -Wl,--whole-archive $$FF_LIB_DIR/libavdevice.a -Wl,--no-whole-archive
+        LIBS += $$FF_LIB_DIR/libavfilter.a \
+                $$FF_LIB_DIR/libavformat.a \
+                $$FF_LIB_DIR/libavcodec.a \
+                $$FF_LIB_DIR/libswresample.a \
+                $$FF_LIB_DIR/libswscale.a \
+                $$FF_LIB_DIR/libavutil.a
+        exists($$FF_LIB_DIR/libjpeg.a):        LIBS += $$FF_LIB_DIR/libjpeg.a
+        exists($$FF_LIB_DIR/libturbojpeg.a):   LIBS += $$FF_LIB_DIR/libturbojpeg.a
+        exists($$FF_LIB_DIR/libpostproc.a):    LIBS += $$FF_LIB_DIR/libpostproc.a
+        # Third-party / MSYS2 deps
+        exists($$MSYS_LIB_DIR/libz.a):          LIBS += $$MSYS_LIB_DIR/libz.a
+        exists($$MSYS_LIB_DIR/libbz2.a):        LIBS += $$MSYS_LIB_DIR/libbz2.a
+        exists($$MSYS_LIB_DIR/liblzma.a):       LIBS += $$MSYS_LIB_DIR/liblzma.a
+        exists($$MSYS_LIB_DIR/libwinpthread.a): LIBS += $$MSYS_LIB_DIR/libwinpthread.a
+        exists($$MSYS_LIB_DIR/libmfx.a):        LIBS += $$MSYS_LIB_DIR/libmfx.a
+        exists($$MSYS_LIB_DIR/libiconv.a):      LIBS += $$MSYS_LIB_DIR/libiconv.a
+        # System libs (resolve refs from FFmpeg archives above)
+        LIBS += -lgdi32 -lvfw32 -lshlwapi \
+                -lws2_32 -lbcrypt -lsecur32 -lwinmm -luuid \
+                -lole32 -loleaut32 -lstrmiids \
+                -lmfuuid -lmfplat -lmf -lmfreadwrite -lwmcodecdspuuid \
+                -lwinpthread
+
+        DEFINES += HAVE_FFMPEG
     }
 
-    # Add additional system libraries FFmpeg objects may depend on (Windows)
-    LIBS += -lws2_32 -lwsock32 -lbcrypt -lbz2 -llzma -lsecur32 -lshlwapi -lwinmm
-    
-    # Or if you installed oneVPL elsewhere, point to that lib dir:
-    # LIBS += -L"C:/Program Files (x86)/Intel/oneVPL/lib" -lmfx
-    # Add FFmpeg support for Windows
-    DEFINES += HAVE_FFMPEG
-
-    # Add libjpeg-turbo for Windows (commented out - not available)
-    # LIBS += -ljpeg
-    # DEFINES += HAVE_LIBJPEG_TURBO
-
-    # Add libjpeg-turbo for Windows (commented out - not available)
-    # LIBS += -ljpeg
-    # DEFINES += HAVE_LIBJPEG_TURBO
+    # Media Foundation backend is always built on Windows (independent of FFmpeg mode).
+    LIBS += -lmf -lmfplat -lmfreadwrite -lmfuuid -lshlwapi -lole32 -loleaut32
 
     RESOURCES += driver/windows/drivers.qrc
 }

--- a/serial/SerialPortManager.cpp
+++ b/serial/SerialPortManager.cpp
@@ -2055,8 +2055,12 @@ void SerialPortManager::completePortCloseCleanup() {
     stopConnectionWatchdog();
     
     // Use the existing signal for port state changes
+    // ponytail: capture state at emit time, not at queue time — prevents stale
+    // "Port disconnected" from overwriting "Port connected" during close/reopen cycles
     QMetaObject::invokeMethod(this, [this]() {
-        emit statusUpdate("Port disconnected");
+        if (!serialPort || !serialPort->isOpen()) {
+            emit statusUpdate("Port disconnected");
+        }
     }, Qt::QueuedConnection);
 }
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -204,6 +204,7 @@ void MainWindow::startServer(){
     // 6. Mark server as running and update status indicator
     m_tcpServerRunning = true;
     if (m_statusBarManager) {
+        m_statusBarManager->setTcpServerVisible(true);
         m_statusBarManager->setStatusUpdate(QString("TCP Server running on port %1").arg(SERVER_PORT));
     }
 
@@ -351,7 +352,8 @@ void MainWindow::stopServer(){
     // Mark server as stopped and update status indicator
     m_tcpServerRunning = false;
     if (m_statusBarManager) {
-        m_statusBarManager->setStatusUpdate(QString("TCP Server stopped"));
+        m_statusBarManager->setTcpServerVisible(false);
+        m_statusBarManager->setStatusUpdate(QString());
     }
     
     // Update menu action to show server is stopped

--- a/ui/statusbar/statusbarmanager.cpp
+++ b/ui/statusbar/statusbarmanager.cpp
@@ -53,11 +53,12 @@ void StatusBarManager::initStatusBar()
     keyLayout->addWidget(keyLabel);
     m_statusBar->addWidget(keyContainer);
 
-    // TCP Server keys display
+    // TCP Server keys display - hidden by default, shown when TCP server starts
     tcpKeyLabel = new QLabel(m_statusBar);
     tcpKeyLabel->setFixedWidth(150);
     tcpKeyLabel->setText("TCP: -");
     tcpKeyLabel->setStyleSheet("color: #0066cc;");
+    tcpKeyLabel->hide();
     m_statusBar->addWidget(tcpKeyLabel);
 
     QWidget *statusMessageContainer = new QWidget(m_statusBar);
@@ -162,6 +163,11 @@ void StatusBarManager::onTcpServerKeyHandled(const QString& key)
         tcpKeyLabel->setText("TCP: -");
         tcpKeyLabel->setStyleSheet("color: #0066cc;");
     }
+}
+
+void StatusBarManager::setTcpServerVisible(bool visible)
+{
+    tcpKeyLabel->setVisible(visible);
 }
 
 void StatusBarManager::onLastMouseLocation(const QPoint& location, const QString& mouseEvent)

--- a/ui/statusbar/statusbarmanager.h
+++ b/ui/statusbar/statusbarmanager.h
@@ -38,6 +38,7 @@ public:
     void setRecordingTime(const QString& time);
     void showRecordingIndicator(bool show);
     void onTcpServerKeyHandled(const QString& key);
+    void setTcpServerVisible(bool visible);
     void setHideKeyboardInput(bool hide);
 
 


### PR DESCRIPTION
## Changes

- **fix(statusbar)**: Prevent stale 'Port disconnected' message and hide TCP label when server inactive
- **fix(mf)**: Fix Media Foundation video capture (color, FPS counter, device init)
- **fix(qmake)**: Align win32 build with cmake, fix 0xC0000409 crash
- **docs**: Remove Qt Multimedia as selectable video backend option

## Testing
- Tested on Windows with Media Foundation backend
- Verified statusbar shows correct connection state
- TCP label properly hidden when server not running