### PR TITLE
feat: add frame timeout detection with camera permission warning

### DIFF
--- a/host/cameramanager.cpp
+++ b/host/cameramanager.cpp
@@ -54,6 +54,20 @@ CameraManager::CameraManager(QObject *parent)
     // Setup Windows-specific hotplug monitoring
     setupWindowsHotplugMonitoring();
 
+    // Initialize frame timeout timer - repeats every 10s to check if frames are still arriving
+    m_frameTimeoutTimer = new QTimer(this);
+    m_frameTimeoutTimer->setSingleShot(false);  // Repeating timer
+    connect(m_frameTimeoutTimer, &QTimer::timeout, this, [this]() {
+        // Check if we've received frames recently and haven't already warned
+        // Also trigger if camera was attempted but never started streaming
+        bool shouldWarn = !isCameraStreaming() && !m_frameTimeoutWarningShown;
+        if (shouldWarn) {
+            qCWarning(log_ui_camera) << "Frame timeout: no video frames received in last 5 seconds";
+            m_frameTimeoutWarningShown = true;
+            emit frameTimeout();
+        }
+    });
+
     // NOTE: Old hotplug monitor connection disabled — DeviceLifecycleManager handles this now.
     // connectToHotplugMonitor();  // Disabled to avoid clash with MainWindow camera initialization
 
@@ -93,6 +107,13 @@ CameraManager::CameraManager(QObject *parent)
                         sessionKey, InterfaceType::Camera);
                 } else {
                     qCWarning(log_ui_camera) << "[Lifecycle] Camera connect failed for session" << sessionKey;
+                    // Start frame timeout monitoring even on failure - user needs to know
+                    // Only start if not already running to avoid resetting on retries
+                    if (m_frameTimeoutTimer && !m_frameTimeoutTimer->isActive()) {
+                        m_frameTimeoutWarningShown = false;
+                        m_frameTimeoutTimer->start(10000);
+                        qCDebug(log_ui_camera) << "Frame timeout monitoring started after connection failure (10s)";
+                    }
                     DeviceLifecycleManager::getInstance().notifyInterfaceFailed(
                         sessionKey, InterfaceType::Camera, "switchToCameraDeviceByPortChain failed");
                 }
@@ -255,12 +276,23 @@ void CameraManager::initializeBackendHandler()
                         this, [this](const QString& devicePath) {
                             qCInfo(log_ui_camera) << "FFmpeg device activated:" << devicePath;
                             emit cameraActiveChanged(true);
+                            // Reset timeout warning flag and start monitoring
+                            // Only start if not already running to avoid resetting on retries
+                            if (m_frameTimeoutTimer && !m_frameTimeoutTimer->isActive()) {
+                                m_frameTimeoutWarningShown = false;
+                                m_frameTimeoutTimer->start(10000);  // Check every 10 seconds
+                                qCDebug(log_ui_camera) << "Frame timeout monitoring started (10s interval)";
+                            }
                         });
                         
                 connect(ffmpegHandler, &FFmpegBackendHandler::deviceDeactivated,
                         this, [this](const QString& devicePath) {
                             qCInfo(log_ui_camera) << "FFmpeg device deactivated:" << devicePath;
                             emit cameraActiveChanged(false);
+                            // Stop frame timeout monitoring
+                            if (m_frameTimeoutTimer) {
+                                m_frameTimeoutTimer->stop();
+                            }
                         });
                         
                 connect(ffmpegHandler, &FFmpegBackendHandler::waitingForDevice,
@@ -379,6 +411,14 @@ void CameraManager::startCamera()
         // Start backend camera
         m_backendHandler->startCamera();
 
+        // Start frame timeout monitoring - will warn if no frames arrive
+        // Only start if not already running to avoid resetting on retries
+        if (m_frameTimeoutTimer && !m_frameTimeoutTimer->isActive()) {
+            m_frameTimeoutWarningShown = false;
+            m_frameTimeoutTimer->start(10000);  // Check every 10 seconds
+            qCDebug(log_ui_camera) << "Frame timeout monitoring started (10s interval)";
+        }
+
         // FFmpeg reports real readiness asynchronously via deviceActivated.
         // Avoid optimistic success state that can produce a black screen with "active=true".
         if (!isFFmpegBackend()) {
@@ -398,7 +438,12 @@ void CameraManager::startCamera()
 void CameraManager::stopCamera()
 {
     qCDebug(log_ui_camera) << "Stopping camera with FFmpeg backend";
-    
+
+    // Stop frame timeout monitoring
+    if (m_frameTimeoutTimer) {
+        m_frameTimeoutTimer->stop();
+    }
+
     try {
         if (m_backendHandler) {
             qCDebug(log_ui_camera) << "Stopping FFmpeg backend camera";
@@ -408,7 +453,7 @@ void CameraManager::stopCamera()
         } else {
             qCWarning(log_ui_camera) << "No backend handler available";
         }
-        
+
     } catch (const std::exception& e) {
         qCritical() << "Exception stopping camera:" << e.what();
     } catch (...) {

--- a/host/cameramanager.h
+++ b/host/cameramanager.h
@@ -132,6 +132,7 @@ signals:
     void recordingStopped();
     void recordingError(const QString &errorString);
     void cameraError(const QString &errorString);
+    void frameTimeout();  // Emitted when no frames received after camera activation
     void resolutionsUpdated(int input_width, int input_height, float input_fps, int capture_width, int capture_height, int capture_fps, float pixelClk);
     void imageCaptured(int id, const QImage& img);
     void lastImagePath(const QString& imagePath);
@@ -205,7 +206,9 @@ private:
     QString m_currentCameraPortChain;  // Track the port chain of current camera device
     qint64 m_lastFrameTimestamp = 0;   // Timestamp (ms since epoch) of last received frame
     QList<QCameraDevice> m_availableCameraDevices;
-    
+    QTimer* m_frameTimeoutTimer = nullptr;  // Detects when no frames are received
+    bool m_frameTimeoutWarningShown = false;  // Only warn once per session
+
     // Recording management
     QString m_currentRecordingPath;  // Path to the current recording file
 

--- a/ui/initializer/mainwindowinitializer.cpp
+++ b/ui/initializer/mainwindowinitializer.cpp
@@ -438,6 +438,7 @@ void MainWindowInitializer::connectCameraSignals()
     qCDebug(log_ui_mainwindowinitializer) << "Connecting camera signals...";
     connect(m_cameraManager, &CameraManager::cameraActiveChanged, m_mainWindow, &MainWindow::updateCameraActive);
     connect(m_cameraManager, &CameraManager::cameraError, m_mainWindow, &MainWindow::displayCameraError);
+    connect(m_cameraManager, &CameraManager::frameTimeout, m_mainWindow, &MainWindow::onFrameTimeout);
     connect(m_cameraManager, &CameraManager::imageCaptured, m_mainWindow, &MainWindow::processCapturedImage);
     connect(m_deviceCoordinator, &DeviceCoordinator::deviceSwitchCompleted, m_mainWindow, &MainWindow::onDeviceSwitchCompleted);
     connect(m_deviceCoordinator, &DeviceCoordinator::deviceSelected, m_mainWindow, &MainWindow::onDeviceSelected);

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -1196,7 +1196,8 @@ void MainWindow::onFrameTimeout()
 {
     qCWarning(log_ui_mainwindow) << "Frame timeout detected - no video frames received";
 
-    // Check if camera devices are visible - if not, it's likely a permission issue
+#ifdef Q_OS_WIN
+    // Windows-specific: Check if camera devices are visible - if not, it's likely a permission issue
     int cameraCount = m_cameraManager->getAvailableCameraDevices().size();
     bool permissionIssue = (cameraCount == 0);
 
@@ -1232,6 +1233,12 @@ void MainWindow::onFrameTimeout()
                 tr("Video backend changed to FFmpeg.\nPlease restart the application for changes to take effect."));
         }
     }
+#else
+    // Linux/other: Simple frame timeout message
+    QMessageBox::warning(this, tr("No Video Signal"),
+        tr("No video frames have been received from the camera.\n\n"
+           "Please check your camera connection and permissions."));
+#endif
 }
 
 void MainWindow::stop(){

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -1182,13 +1182,55 @@ void MainWindow::displayCameraError()
     qCWarning(log_ui_mainwindow) << "Camera error: " << m_camera->errorString();
     if (m_camera->error() != QCamera::NoError) {
         qCDebug(log_ui_mainwindow) << "Camera error detected, switching to help pane";
-        
+
         // Safely switch to help pane
         QMetaObject::invokeMethod(this, [this]() {
             stackedLayout->setCurrentIndex(0);
         }, Qt::QueuedConnection);
 
         stop();
+    }
+}
+
+void MainWindow::onFrameTimeout()
+{
+    qCWarning(log_ui_mainwindow) << "Frame timeout detected - no video frames received";
+
+    // Check if camera devices are visible - if not, it's likely a permission issue
+    int cameraCount = m_cameraManager->getAvailableCameraDevices().size();
+    bool permissionIssue = (cameraCount == 0);
+
+    QMessageBox::StandardButton reply;
+    QString message;
+
+    if (permissionIssue) {
+        message = tr("No camera devices detected.\n\n"
+                     "This is usually caused by Windows camera privacy settings blocking the app.\n\n"
+                     "To fix: Go to Windows Settings → Privacy → Camera → "
+                     "enable 'Allow desktop apps to access your camera'.\n\n"
+                     "Would you like to open Camera privacy settings now?");
+        reply = QMessageBox::question(this, tr("Camera Permission Required"), message,
+                                      QMessageBox::Yes | QMessageBox::No);
+
+        if (reply == QMessageBox::Yes) {
+            // Open Windows camera privacy settings
+            QDesktopServices::openUrl(QUrl("ms-settings:privacy-webcam"));
+            qCInfo(log_ui_mainwindow) << "Opened Windows camera privacy settings";
+        }
+    } else {
+        message = tr("No video frames have been received from the camera.\n\n"
+                     "This may indicate the video backend cannot decode the signal.\n"
+                     "Would you like to switch to FFmpeg backend (recommended for Windows)?");
+        reply = QMessageBox::question(this, tr("No Video Signal"), message,
+                                      QMessageBox::Yes | QMessageBox::No);
+
+        if (reply == QMessageBox::Yes) {
+            GlobalSetting::instance().setMediaBackend("ffmpeg");
+            qCInfo(log_ui_mainwindow) << "User chose to switch to FFmpeg backend";
+
+            QMessageBox::information(this, tr("Backend Changed"),
+                tr("Video backend changed to FFmpeg.\nPlease restart the application for changes to take effect."));
+        }
     }
 }
 

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -187,6 +187,7 @@ private slots:
     void openKeyboardMapEditor();
 
     void displayCameraError();
+    void onFrameTimeout();  // Warn user when no video frames are received
 
     void updateCameraActive(bool active);
     void onDeviceSwitchCompleted();


### PR DESCRIPTION
## Summary

Adds frame timeout detection to alert users when no video frames arrive after camera activation — most commonly caused by Windows camera privacy settings blocking desktop app access.

## Changes

- **Frame timeout monitoring** in `CameraManager` — a repeating 10s timer checks whether frames are arriving after camera start/connection failure; emits `frameTimeout()` signal if not
- **Windows-specific permission dialog** in `MainWindow::onFrameTimeout` — if no camera devices are visible, shows a prompt explaining how to fix privacy settings and offers to open `ms-settings:privacy-webcam` directly
- **Backend switch prompt** — when devices are visible but frames aren't arriving, offers to switch to FFmpeg backend (recommended for Windows)
- **Linux/other fallback** — simple warning dialog advising to check connection/permissions
- Timer starts on camera start, connection failure, or FFmpeg device activation; stops on camera stop or device deactivation

## Files changed

| File | Change |
|---|---|
| `host/cameramanager.cpp/h` | Frame timeout timer, signal, start/stop lifecycle |
| `ui/mainwindow.cpp/h` | `onFrameTimeout()` handler with platform-specific dialogs |
| `ui/initializer/mainwindowinitializer.cpp` | Wire `frameTimeout` signal to slot |