### PR TITLE
fix(rpm): libbz2.so.1.0 self-referential symlink in %post

### DIFF
--- a/packaging/rpm/spec
+++ b/packaging/rpm/spec
@@ -811,17 +811,18 @@ if [ -d /usr/lib/openterfaceqt ]; then
     echo "Creating symlinks for bundled core libraries..."
     
     # Compression libraries (zlib variants)
-    # Use find with two-dot pattern to match fully-versioned real files only
-    # (e.g. libz.so.1.2.11), excluding sonames like libz.so.1 which would
-    # produce self-referential symlinks.
-    base_z=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libz.so.*.*" -type f 2>/dev/null | head -1)
+    # Use find with three-dot pattern (*.so.*.*.*) to match fully-versioned real
+    # files only (e.g. libz.so.1.2.11 = 3 segments after .so), excluding sonames
+    # (libz.so.1 = 1 segment, libbz2.so.1.0 = 2 segments) which would produce
+    # self-referential symlinks.
+    base_z=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libz.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_z" ] && [ ! -L /usr/lib/openterfaceqt/libz.so.1 ]; then
         ln -sf "$(basename "$base_z")" /usr/lib/openterfaceqt/libz.so.1 2>/dev/null || true
         echo "  ✅ Created symlink: libz.so.1 -> $(basename "$base_z")"
     fi
 
     # Hardware acceleration libraries (VDPAU only - libva is now system dependency)
-    base_vdpau=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libvdpau.so.*.*" -type f 2>/dev/null | head -1)
+    base_vdpau=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libvdpau.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_vdpau" ] && [ ! -L /usr/lib/openterfaceqt/libvdpau.so.1 ]; then
         ln -sf "$(basename "$base_vdpau")" /usr/lib/openterfaceqt/libvdpau.so.1 2>/dev/null || true
         echo "  ✅ Created symlink: libvdpau.so.1 -> $(basename "$base_vdpau")"
@@ -829,29 +830,32 @@ if [ -d /usr/lib/openterfaceqt ]; then
 
     # NOTE: libva is now a system dependency, not bundled
     # This prevents symbol conflicts with system libavutil (vaMapBuffer2)
-    
+
     # USB device access
-    base_usb=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libusb-1.0.so.*.*" -type f 2>/dev/null | head -1)
+    base_usb=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libusb-1.0.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_usb" ] && [ ! -L /usr/lib/openterfaceqt/libusb-1.0.so.0 ]; then
         ln -sf "$(basename "$base_usb")" /usr/lib/openterfaceqt/libusb-1.0.so.0 2>/dev/null || true
         echo "  ✅ Created symlink: libusb-1.0.so.0 -> $(basename "$base_usb")"
     fi
 
     # JPEG libraries
-    base_tjpeg=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libturbojpeg.so.*.*" -type f 2>/dev/null | head -1)
+    base_tjpeg=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libturbojpeg.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_tjpeg" ] && [ ! -L /usr/lib/openterfaceqt/libturbojpeg.so.0 ]; then
         ln -sf "$(basename "$base_tjpeg")" /usr/lib/openterfaceqt/libturbojpeg.so.0 2>/dev/null || true
         echo "  ✅ Created symlink: libturbojpeg.so.0 -> $(basename "$base_tjpeg")"
     fi
 
-    base_jpeg=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libjpeg.so.*.*" -type f 2>/dev/null | head -1)
+    base_jpeg=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libjpeg.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_jpeg" ] && [ ! -L /usr/lib/openterfaceqt/libjpeg.so.8 ]; then
         ln -sf "$(basename "$base_jpeg")" /usr/lib/openterfaceqt/libjpeg.so.8 2>/dev/null || true
         echo "  ✅ Created symlink: libjpeg.so.8 -> $(basename "$base_jpeg")"
     fi
 
     # Compression libraries (bzip2)
-    base_bz=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libbz2.so.*.*" -type f 2>/dev/null | head -1)
+    # Critical: libbz2's soname (libbz2.so.1.0) has two dot-segments, so a
+    # two-dot find pattern would match the soname itself and produce a
+    # self-referential symlink. Three-dot pattern (*.so.*.*.*) excludes it.
+    base_bz=$(find /usr/lib/openterfaceqt -maxdepth 1 -name "libbz2.so.*.*.*" -type f 2>/dev/null | head -1)
     if [ -n "$base_bz" ] && [ ! -L /usr/lib/openterfaceqt/libbz2.so.1.0 ]; then
         ln -sf "$(basename "$base_bz")" /usr/lib/openterfaceqt/libbz2.so.1.0 2>/dev/null || true
         echo "  ✅ Created symlink: libbz2.so.1.0 -> $(basename "$base_bz")"


### PR DESCRIPTION
## Summary

Follow-up to #625. The `*.so.*.*` find pattern in RPM `%post` correctly fixed most bundled-lib symlinks but missed `libbz2.so.1.0` because its soname has two dot-segments (1.0) instead of one. The pattern matched both the soname and the real file, producing `libbz2.so.1.0 -> libbz2.so.1.0` — breaking all system commands that depend on libbz2 (tee, sed, tr, date, grep).

## Fix

Change find pattern from `*.so.*.*` (two dot-segments) to `*.so.*.*.*` (three dot-segments) across all six library blocks. This excludes sonames with one or two segments while still matching fully-versioned real files like `libbz2.so.1.0.4`.

| Library | Soname | Real file | Old pattern matches | New pattern matches |
|---|---|---|---|---|
| libz | `libz.so.1` (1 seg) | `libz.so.1.2.11` | ✅ real only | ✅ real only |
| libvdpau | `libvdpau.so.1` (1 seg) | `libvdpau.so.1.0.0` | ✅ real only | ✅ real only |
| libusb | `libusb-1.0.so.0` (1 seg) | `libusb-1.0.so.0.4.0` | ✅ real only | ✅ real only |
| libturbojpeg | `libturbojpeg.so.0` (1 seg) | `libturbojpeg.so.0.3.0` | ✅ real only | ✅ real only |
| libjpeg | `libjpeg.so.8` (1 seg) | `libjpeg.so.8.3.2` | ✅ real only | ✅ real only |
| **libbz2** | **`libbz2.so.1.0` (2 seg)** | **`libbz2.so.1.0.4`** | **❌ both (picks soname)** | **✅ real only** |

## Test plan

- [x] Built RPM from patched spec
- [x] Installed on Fedora 43 via `dnf install` (no `--nodeps` needed)
- [x] All 6 symlinks resolve correctly
- [x] App launches successfully and establishes hardware communication
- [ ] CI: RPM build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)