### PR TITLE
CameraManager: fix use-after-free in the deferred camera retry chains (SIGSEGV on device switch)

### DIFF
--- a/host/cameramanager.cpp
+++ b/host/cameramanager.cpp
@@ -35,6 +35,7 @@
 #include <QThread>
 #include <algorithm>
 #include <functional>
+#include <memory>
 #include <QSet>
 #include "log/opflogging.h"
 
@@ -186,8 +187,13 @@ CameraManager::CameraManager(QObject *parent)
                 // HOTFIX (2026-09): Increased delays for USB re-enumeration stability.
                 // Camera can disappear briefly during USB re-enumeration (~2s).
                 constexpr int MAX_CAMERA_CONNECT_RETRIES = 4;
-                std::function<void(int)> tryConnectCamera;
-                tryConnectCamera = [this, sessionKey, portChain, &tryConnectCamera](int attempt) {
+                // The retry chain is deferred through QTimer, so the callable must outlive
+                // this handler's stack frame. Own it through a shared_ptr and let each pending
+                // timer hold a strong reference; the body keeps only a weak one, so there is
+                // no ownership cycle and the callable is released once no retry is pending.
+                auto tryConnectCamera = std::make_shared<std::function<void(int)>>();
+                std::weak_ptr<std::function<void(int)>> weakConnectCamera = tryConnectCamera;
+                *tryConnectCamera = [this, sessionKey, portChain, weakConnectCamera](int attempt) {
                     qWarning() << "[HOTPLUG-CAM] Camera connect attempt" << attempt + 1
                                << "/" << MAX_CAMERA_CONNECT_RETRIES
                                << "for portChain=" << portChain;
@@ -228,9 +234,11 @@ CameraManager::CameraManager(QObject *parent)
                             int retryDelay = 1500 + (attempt * 500);
                             qWarning() << "[HOTPLUG-CAM] Scheduling camera retry in"
                                        << retryDelay << "ms";
-                            QTimer::singleShot(retryDelay, this, [tryConnectCamera, attempt]() {
-                                tryConnectCamera(attempt + 1);
-                            });
+                            if (auto self = weakConnectCamera.lock()) {
+                                QTimer::singleShot(retryDelay, this, [self, attempt]() {
+                                    (*self)(attempt + 1);
+                                });
+                            }
                         } else {
                             qWarning() << "[HOTPLUG-CAM] Camera connect FAILED after all retries"
                                        << "for portChain=" << portChain;
@@ -258,7 +266,7 @@ CameraManager::CameraManager(QObject *parent)
                 constexpr int kInitialConnectDelayMs = 300;
 #endif
                 QTimer::singleShot(kInitialConnectDelayMs, this, [tryConnectCamera]() {
-                    tryConnectCamera(0);
+                    (*tryConnectCamera)(0);
                 });
             });
 
@@ -322,8 +330,11 @@ CameraManager::CameraManager(QObject *parent)
             // HOTFIX (2026-09): Increased delays for USB re-enumeration stability.
             // Openterface camera can disappear briefly during USB re-enumeration (~2s).
             constexpr int MAX_SERIAL_RECOVERY_RETRIES = 4;
-            std::function<void(int)> tryRestartCamera;
-            tryRestartCamera = [this, portChain, &tryRestartCamera](int attempt) {
+            // Same lifetime rule as the hotplug retry chain above: the callable is reached
+            // through QTimer after this handler has returned, so it cannot live on the stack.
+            auto tryRestartCamera = std::make_shared<std::function<void(int)>>();
+            std::weak_ptr<std::function<void(int)>> weakRestartCamera = tryRestartCamera;
+            *tryRestartCamera = [this, portChain, weakRestartCamera](int attempt) {
                 qWarning() << "[HOTPLUG-CAM][SerialRecovery] Camera restart attempt" << attempt + 1
                            << "/" << MAX_SERIAL_RECOVERY_RETRIES << "for portChain=" << portChain;
 
@@ -359,9 +370,11 @@ CameraManager::CameraManager(QObject *parent)
                         // 1500ms, 2000ms, 2500ms (was 500ms, 1000ms, 1500ms)
                         int retryDelay = 1500 + (attempt * 500);
                         qWarning() << "[HOTPLUG-CAM][SerialRecovery] Retrying in" << retryDelay << "ms";
-                        QTimer::singleShot(retryDelay, this, [tryRestartCamera, attempt]() {
-                            tryRestartCamera(attempt + 1);
-                        });
+                        if (auto self = weakRestartCamera.lock()) {
+                            QTimer::singleShot(retryDelay, this, [self, attempt]() {
+                                (*self)(attempt + 1);
+                            });
+                        }
                     } else {
                         qWarning() << "[HOTPLUG-CAM][SerialRecovery] Camera restart FAILED after all retries";
                     }
@@ -376,7 +389,7 @@ CameraManager::CameraManager(QObject *parent)
             constexpr int kSerialRecoveryDelayMs = 300;
 #endif
             QTimer::singleShot(kSerialRecoveryDelayMs, this, [tryRestartCamera]() {
-                tryRestartCamera(0);
+                (*tryRestartCamera)(0);
             });
         });
 


### PR DESCRIPTION
Both camera retry chains added in #630 declare a `std::function<void(int)>` as a **local** inside a signal-handler lambda, assign it a lambda that captures it **by reference**, and then copy that `std::function` into `QTimer::singleShot` lambdas:

```cpp
std::function<void(int)> tryRestartCamera;
tryRestartCamera = [this, portChain, &tryRestartCamera](int attempt) {
    ...
    QTimer::singleShot(retryDelay, this, [tryRestartCamera, attempt]() {
        tryRestartCamera(attempt + 1);
    });
};
QTimer::singleShot(kSerialRecoveryDelayMs, this, [tryRestartCamera]() {
    tryRestartCamera(0);
});
```

Copying the `std::function` duplicates the object, but its body still refers to the local through the captured reference. The handler returns immediately, the local is destroyed, and when the timer fires hundreds of milliseconds later the body dereferences a dangling stack reference.

### Symptom

Under repeated device switching this is a reliable crash. Caught under gdb:

```
Thread 1 "openterfaceQT" received signal SIGSEGV, Segmentation fault.
#0  0x00000000f333293c in ??? ()
#1  std::function<void (int)>::function(std::function<void (int)> const&)
#2  CameraManager::CameraManager(QObject*)::{lambda(QString const&)#2}::
        operator()(QString const&) const::{lambda(int)#1}::operator()(int) const
#4  QtPrivate::QCallableObject<...>::impl(...)
#10 QTimerInfoList::activateTimers()
```

Note frame #10: it fires from the timer queue, not from the caller that requested the switch. In our testing a headless instance died within a handful of switch cycles.

### Fix

Own the callable through a `shared_ptr`. Each pending timer lambda holds a **strong** reference — which is exactly what has to keep it alive across the deferral — while the body holds only a **weak** one, so there is no ownership cycle and the callable is released once no retry is outstanding.

Capturing the `shared_ptr` strongly inside itself would also stop the crash, but it would leak one `std::function` per invocation, which is why it is written this way.

Both sites are affected: the `shouldConnectCamera` hotplug retry chain and the `serialPortConnectionSuccess` recovery chain.

### Testing

Built and run headless (`--backend ffmpeg`) against four Openterface units on one hub, driving continuous device switching for 20 minutes per group. Before: SIGSEGV within a few cycles. After: 29 cycles across 40 minutes with no crash and no enumeration dropouts.