### PR TITLE
ffmpeg backend: emit frameReceived so the frame-timeout watchdog sees the stream

### DIFF
--- a/host/backend/ffmpegbackendhandler.cpp
+++ b/host/backend/ffmpegbackendhandler.cpp
@@ -817,6 +817,16 @@ void FFmpegBackendHandler::processFrame()
         // holds its own ~8 MB buffer in the queue, rapidly exhausting RAM and
         // triggering "QImage: out of memory" warnings at high frame rates.
         if (m_captureRunning) {
+            // Report that a frame arrived, independently of whether it is forwarded
+            // for rendering. The backpressure check below deliberately drops frames
+            // when the GUI is behind, and in headless MCP mode there is no VideoPane
+            // consuming them at all -- so a frame-alive timestamp keyed off
+            // frameReadyImage (or off VideoPane::newVideoFrameReceived) is never
+            // updated on this backend. CameraManager::isCameraStreaming() then stays
+            // false while the device streams normally, and the frame-timeout watchdog
+            // tears down a healthy capture and fails to restart it. GStreamer already
+            // emits this signal for the same reason.
+            emit frameReceived();
             if (m_frameCount <= 5) {
                 qCDebug(log_ffmpeg_backend) << "Emitting frameReadyImage signal for frame" << m_frameCount;
             }


### PR DESCRIPTION
`MultimediaBackendHandler::frameReceived()` is what keeps `CameraManager`'s frame-alive timestamp fresh. It is emitted in **exactly one place in the tree** — the GStreamer backend (`gstreamerbackendhandler.cpp`). The FFmpeg backend never emits it.

`CameraManager` has only two ways to learn that frames are flowing:

- `MultimediaBackendHandler::frameReceived` (`cameramanager.cpp:538`)
- `VideoPane::newVideoFrameReceived` (`cameramanager.cpp:1870`)

In headless MCP mode there is no `VideoPane`, so the second is unavailable; and with `--backend ffmpeg` the first never fires. `m_lastFrameTimestamp` therefore stays zero for the life of the process, and `isCameraStreaming()` returns false permanently — while the device is delivering 29 fps.

The existing comment at `cameramanager.cpp:533` already states the intent: *"Connect frameReceived signal so backends that render outside the Qt graphics path can keep the frame-alive timestamp fresh. Without this, the frame-timeout watchdog falsely reports no video signal."* GStreamer satisfies it; FFmpeg does not.

### Consequences, all self-inflicted

- The frame-timeout watchdog reports "no frames received" against a healthy stream, restarts the camera and stops the capture.
- The restart then fails with `No matching camera found for port chain`, leaving the camera dead for the rest of the process.
- `capture_screen` keeps returning the last frame taken before the teardown. The file is still rewritten on every call, so **only the checksum reveals the image is frozen** — the size looks entirely plausible.
- `system_status` reports `camera.active = false` while the device streams.
- The serial-recovery path sees a not-streaming camera and arms a restart that was never needed.

Observed sequence in a headless instance:

```
Camera ready! First frame: 1920 x 1080
Performance: Actual FPS: 28.9  Frames: 240  Elapsed: 8302 ms
Frame timeout: no frames received, attempting camera restart 3 / 3
processFrame: Early exit - captureRunning: false
[HOTPLUG-CAM] No matching camera found for port chain: "1-3"
Camera restart failed on retry 3
```

A device switch happens to restart the stream, which is why this is largely invisible in interactive use — and why it is fatal for a long-running headless instance that never switches.

### Fix

Emit `frameReceived()` for every decoded frame while capturing, **before** the backpressure check. The signal reports *liveness*, not delivery: a frame dropped because the GUI is behind still proves the device is alive, and `frameReadyImage` is deliberately not emitted in that case.

### Testing

Headless, `--backend ffmpeg`, one unit, identical conditions:

| | camera at +25s | +45s | +65s | +125s | frame timeouts |
|---|---|---|---|---|---|
| before | dead | dead | dead | dead | 1 |
| after | alive | alive | alive | alive | **0** |

With four units and one instance each, all four cameras now stream simultaneously and indefinitely at ~29 fps. Verified the captures are genuinely live (changing checksums), not merely present.