### PR TITLE
CameraManager: do not run serial-recovery camera restart before the first frame

### DIFF
--- a/host/cameramanager.cpp
+++ b/host/cameramanager.cpp
@@ -309,6 +309,18 @@ CameraManager::CameraManager(QObject *parent)
                 // No port chain to reconnect to — either initial startup or never had camera.
                 return;
             }
+            if (m_lastFrameTimestamp <= 0) {
+                // No frame has ever arrived, so the initial camera start is still in flight:
+                // the --device bind has already set the port chain, and isCameraStreaming() is
+                // still false simply because the first frame has not landed yet. Neither guard
+                // above holds, so without this the recovery fires against a camera that is
+                // merely starting, tears it down a moment after it goes healthy, and then fails
+                // to restart it ("No matching camera found"), leaving the camera dead.
+                // Recovery restores something that worked; there is nothing to restore yet.
+                qCInfo(log_ui_camera) << "[SerialRecovery] Ignoring serial connect before the"
+                                      << "first frame — initial camera start is still in progress";
+                return;
+            }
             if (isCameraStreaming()) {
                 // Camera is actively streaming — no restart needed.
                 return;


### PR DESCRIPTION
> **Depends on #632.** This change gates on `m_lastFrameTimestamp`, which is only meaningful once the FFmpeg backend actually reports frames. Merged alone it would *suppress* serial recovery on that backend rather than just skipping the start-up window. Please take #632 first, or both together.

`serialPortConnectionSuccess` arms a camera restart whenever a port chain is known and the camera is not streaming:

```cpp
if (portChain.isEmpty()) return;      // "initial startup"
if (isCameraStreaming()) return;      // already streaming
```

At start-up both conditions are met for reasons that have nothing to do with recovery: the initial device bind has already set the port chain, and `isCameraStreaming()` is false only because the first frame has not arrived yet. Neither guard holds, so a restart is scheduled against a camera that is merely still starting.

It then fires ~1.5 s later, stops a camera that has just become healthy, and fails to bring it back:

```
Camera ready! First frame: 1920 x 1080
[HOTPLUG-CAM][SerialRecovery] Camera restart attempt 1 / 4 for portChain= "1-3"
[HOTPLUG-CAM] No devices found in DeviceManager for port chain: "1-3"
[HOTPLUG-CAM] No matching camera found for port chain: "1-3"
[HOTPLUG-CAM][SerialRecovery] Camera restart failed on attempt 1
```

The camera then stays stopped, and `capture_screen` keeps returning the last frame captured before the teardown.

A later device switch happens to repair it, which is why this is hard to see interactively. An instance pinned to one device never switches, so the camera stays dead for the life of the process.

### Fix

Gate the handler on `m_lastFrameTimestamp`, which is written only when a frame is received and never reset. Zero means no frame has ever arrived in this process, so there is nothing to recover yet — recovery restores something that worked.

Genuine recovery is unaffected: by then frames have been received and the timestamp is non-zero.

### Testing

Headless with `--device`, four units each with their own instance. Before: the misfire fires immediately after the camera goes healthy, on every instance. After: `Ignoring serial connect before the first frame` once per instance, zero `Camera restart attempt` lines, and all four cameras streaming continuously.