### PR TITLE
fix(build): OpenCV 5 — missing direct include for cv::boundingRect in screenAnalyzer

### DIFF
--- a/server/mcp/screenAnalyzer.cpp
+++ b/server/mcp/screenAnalyzer.cpp
@@ -32,6 +32,12 @@
 #ifdef HAVE_OPENCV
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
+#if CV_VERSION_MAJOR >= 5
+// OpenCV 5 moved cv::boundingRect(InputArray) from imgproc to the new
+// opencv2/geometry module, and imgproc.hpp no longer provides it
+// transitively. The module does not exist in OpenCV 4, hence the guard.
+#include <opencv2/geometry/2d.hpp>
+#endif
 #endif
 
 Q_LOGGING_CATEGORY(log_screen_analyzer, "opf.screen.analyzer")


### PR DESCRIPTION
## Problem

Building against OpenCV 5 (e.g. Arch Linux, `opencv 5.0.0-9`) fails in
`server/mcp/screenAnalyzer.cpp`:

    error: 'boundingRect' was not declared in this namespace

## Cause

- OpenCV 5 moved `cv::boundingRect(InputArray)` from `imgproc` to the new
  `opencv2/geometry` module (`opencv2/geometry/2d.hpp`).
- `imgproc.hpp` in OpenCV 5 includes only `opencv2/core.hpp`, so the
  declaration is no longer reachable transitively.
- `screenAnalyzer.cpp` calls `cv::boundingRect(contour)` at two call sites
  while including only `core.hpp` and `imgproc.hpp`.

CI does not catch this because it builds against OpenCV 4.

## Fix

Add the include, guarded by `#if CV_VERSION_MAJOR >= 5` — `opencv2/geometry`
does not exist in OpenCV 4.x, so an unconditional include would break OpenCV 4
builds (the mirror-image failure). With the guard, the OpenCV 4 compile path is
unchanged.

## Testing

- Builds clean against `opencv 5.0.0-9` on Arch Linux with the guard open.
- With OpenCV 4 the preprocessed translation unit is identical to before.

Precedent: the OpenCV 5 compatibility fix merged in #630 added this same
header for another file.

Fork branch:
https://github.com/coryleeio/Openterface_QT/tree/fix/opencv5-geometry-include
